### PR TITLE
fix(Fitter): posterior RV phase plot now works for single planet systems

### DIFF
--- a/docs/Examples/example_fitting.ipynb
+++ b/docs/Examples/example_fitting.ipynb
@@ -207,6 +207,38 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "We can also look at the posterior RV to eyeball whether it is a good fit to the data:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "fitter.plot_posterior_rv(discard_start=0, thin=10, save=False)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Because of how spread out the data is over time, that doesn't really tell us much. So let's fold the data over the orbital period, and create an orbital phase plot instead:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "fitter.plot_posterior_phase(discard_start=0, thin=10, save=False)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "## Calculate $M_p\\sin{i}$\n",
     "Now that we have fitted for the parameters, we can investigate the $M_p\\sin{i}$ of 51 Peg b. To do this, we'll pass in the samples from the `Fitter` for the parameters we need. We also need the stellar mass, which I've again obtained from Birkby et al. 2017. The relationship between planetary mass and RV semi-amplitude is given by\n",
     "\n",

--- a/src/ravest/fit.py
+++ b/src/ravest/fit.py
@@ -814,6 +814,10 @@ class Fitter:
         fig, axs = plt.subplots(len(self.planet_letters), figsize=(8, len(self.planet_letters)*10/3), sharex=True)
         fig.subplots_adjust(hspace=0)
 
+        # Ensure axs is always an array for consistent indexing
+        if len(self.planet_letters) == 1:
+            axs = [axs]
+
         # 1) we need the system trend RV
         trend_rv = self._posterior_rv_trend(times=self.time, discard_start=discard_start, discard_end=discard_end, thin=thin)
 


### PR DESCRIPTION
Quick fix to the posterior phase plot to ensure it works when we only have one planet. Previously this function was only tested on the K2-24 notebook, where we fit for two planets. Now, the function works for one planet, and is added to the Peg 51 notebook too.