### PR TITLE
Refactor/params priors getters setters

### DIFF
--- a/docs/Examples/K2-24.ipynb
+++ b/docs/Examples/K2-24.ipynb
@@ -101,8 +101,7 @@
     "          \n",
     "          \"jit\": Parameter(0, \"m/s\", fixed=False),}\n",
     "\n",
-    "fitter.add_params(params)\n",
-    "\n",
+    "fitter.params = params\n",
     "fitter.params"
    ]
   },
@@ -139,7 +138,7 @@
     "          \"jit\": ravest.prior.Uniform(0, 5),\n",
     "         }\n",
     "\n",
-    "fitter.add_priors(priors)\n",
+    "fitter.priors = priors\n",
     "fitter.priors"
    ]
   },
@@ -149,7 +148,7 @@
    "source": [
     "Now that we have loaded the `Fitter` with the data, our parameterisation, our initial parameter values, and priors for each of the free parameters, we can now fit the free parameters of the model to the data.  \n",
     "  \n",
-    "First, Maximum A Posteriori (MAP) optimisation is performed to find the best-fit solution. "
+    "First, Maximum A Posteriori (MAP) optimisation is performed to find the best-fit solution."
    ]
   },
   {
@@ -166,7 +165,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Then, MCMC is used to explore the parameter space and estimate the parameter uncertainties. For the purposes of making this notebook run quickly, this is only running for 10000 steps - you should run considerably more. `ravest` enforces a minimum of at least 2 walkers per each free parameter, again though you should consider running more."
+    "Then, MCMC is used to explore the parameter space and estimate the parameter uncertainties. For the purposes of making this notebook run quickly, this is only running for 10000 steps - you should run considerably more. `ravest` enforces a minimum of at least 2 walkers per each free parameter, again though you should consider running more. You should also consider using randomly initialised starting points, rather than the MAP solution, to better explore the parameter space."
    ]
   },
   {
@@ -369,7 +368,7 @@
     "            \"jit\": Parameter(0, \"m/s\", fixed=False),\n",
     "            }\n",
     "\n",
-    "fitter_se.add_params(params_se)\n",
+    "fitter_se.params = params_se\n",
     "fitter_se.params"
    ]
   },
@@ -394,7 +393,7 @@
     "          \"jit\": ravest.prior.Uniform(0, 5),\n",
     "        }\n",
     "\n",
-    "fitter_se.add_priors(priors_se)\n",
+    "fitter_se.priors = priors_se\n",
     "fitter_se.priors"
    ]
   },

--- a/docs/Examples/example_fitting.ipynb
+++ b/docs/Examples/example_fitting.ipynb
@@ -72,7 +72,7 @@
     "\n",
     "# Construct the params dict\n",
     "# These values will be used as your initial guess for the fit\n",
-    "params = {\"per_b\": Parameter(4.23, \"d\", fixed=False),\n",
+    "params_dict = {\"per_b\": Parameter(4.23, \"d\", fixed=False),\n",
     "          \"k_b\": Parameter(60, \"m/s\", fixed=False),\n",
     "          \"e_b\": Parameter(0, \"\", fixed=True),\n",
     "          \"w_b\": Parameter(np.pi/2, \"rad\", fixed=True),\n",
@@ -83,7 +83,7 @@
     "          \"gdd\": Parameter(0, \"m/s/day^2\", fixed=True),\n",
     "          \"jit\": Parameter(0, \"m/s\", fixed=True),}\n",
     "\n",
-    "fitter.add_params(params)\n",
+    "fitter.params = params_dict\n",
     "fitter.params"
    ]
   },
@@ -94,14 +94,14 @@
    "outputs": [],
    "source": [
     "# Construct the priors dict. Every parameter that isn't fixed requires a prior.\n",
-    "priors = {\n",
+    "priors_dict = {\n",
     "          \"per_b\": ravest.prior.Gaussian(4.2293, 0.0011),\n",
     "          \"k_b\": ravest.prior.Uniform(0,100),\n",
     "          \"tc_b\": ravest.prior.Uniform(2456320, 2456330),\n",
     "          \"g\": ravest.prior.Uniform(-33260, -33240),\n",
     "        }\n",
     "\n",
-    "fitter.add_priors(priors)\n",
+    "fitter.priors = priors_dict\n",
     "fitter.priors"
    ]
   },


### PR DESCRIPTION
Tidy up the UX for adding parameters and priors. Rather than the `add_params` and `add_priors` methods, which could be confusing (and bypassed by directly accessing `Fitter.params` or `Fitter.priors`, we now use getter and setter properties to do the validation. This also means users can update parameters/priors and definitely have the validation performed.