### PR TITLE
Feature/parameterisation priors

### DIFF
--- a/src/ravest/fit.py
+++ b/src/ravest/fit.py
@@ -827,13 +827,13 @@ class Fitter:
                 _w =  params[f"w_{letter}"]
                 _tp = params[f"tp_{letter}"]
                 tc = self.parameterisation.convert_tp_to_tc(_tp, p, _e, _w)
-            # else, convert to default basis, giving us e and w, then get tc
+            # else, convert to default parameterisation, giving us e and w, then get tc
             else:
                 # get the parameterisation for this planet. Combine with planet letter
                 _keys = [f"{par}_{letter}" for par in self.parameterisation.pars]
                 _inpars = {key: samples_df[key] for key in _keys}
-                _default_basis = self.parameterisation.convert_pars_to_default_basis(_inpars)  # dict of converted pars
-                tc = _default_basis["tc"]
+                _default_parameterisation = self.parameterisation.convert_pars_to_default_parameterisation(_inpars)  # dict of converted pars
+                tc = _default_parameterisation["tc"]
 
             # get the median of the p and tc
             p_medians[letter] = np.median(p)

--- a/src/ravest/model.py
+++ b/src/ravest/model.py
@@ -18,7 +18,7 @@ class Planet:
     parameterisation : `parameterisation`
         The set of planetary parameters used to define the planet.
     params : `dict`
-        The orbital parameters, matching the basis.
+        The orbital parameters, matching the parameterisation.
     """
 
     def __init__(self, letter: str, parameterisation: Parameterisation, params: dict):
@@ -32,12 +32,12 @@ class Planet:
         if not set(params.keys()) == set(parameterisation.pars):
             raise ValueError(f"Parameterisation {parameterisation} does not match input params {params}")
 
-        # Convert to the per k e w tp basis that we need for the RV equation
-        self._rvparams = self.parameterisation.convert_pars_to_default_basis(self.params)
+        # Convert to the per k e w tp parameterisation that we need for the RV equation
+        self._rvparams = self.parameterisation.convert_pars_to_default_parameterisation(self.params)
 
         # Validate parameters immediately after conversion to avoid invalid parameters
         # Raises a ValueError if any parameter is invalid
-        self.parameterisation.validate_default_basis_params(self._rvparams)
+        self.parameterisation.validate_default_parameterisation_params(self._rvparams)
 
 
     def __repr__(self):

--- a/src/ravest/param.py
+++ b/src/ravest/param.py
@@ -37,8 +37,8 @@ class Parameterisation:
         if not -np.pi <= w < np.pi:
             raise ValueError(f"Invalid argument of periastron: {w} not in [-pi, +pi)")
 
-    def validate_default_basis_params(self, params_dict):
-        """Validate all parameters in default basis (per k e w tp).
+    def validate_default_parameterisation_params(self, params_dict):
+        """Validate all parameters in default parameterisation (per k e w tp).
 
         Parameters
         ----------
@@ -172,7 +172,7 @@ class Parameterisation:
         esinw = e * np.sin(w)
         return ecosw, esinw
 
-    def convert_pars_to_default_basis(self, inpars) -> dict:
+    def convert_pars_to_default_parameterisation(self, inpars) -> dict:
         if self.parameterisation == "per k e w tp":
             return {"per": inpars["per"],
                     "k": inpars["k"],
@@ -221,6 +221,70 @@ class Parameterisation:
                     "e": e,
                     "w": w,
                     "tp": tp}
+
+        else:
+            raise ValueError(f"parameterisation {self.parameterisation} not recognised")
+
+    def convert_pars_from_default_parameterisation(self, default_pars) -> dict:
+        """Convert parameters from default (per k e w tp) to this parameterisation.
+
+        Parameters
+        ----------
+        default_pars : dict
+            Dictionary with keys: per, k, e, w, tp
+
+        Returns
+        -------
+        dict
+            Parameters in this parameterisation
+        """
+        if self.parameterisation == "per k e w tp":
+            return {key: default_pars[key] for key in self.pars}
+
+        elif self.parameterisation == "per k e w tc":
+            tc = self.convert_tp_to_tc(default_pars["tp"], default_pars["per"],
+                                      default_pars["e"], default_pars["w"])
+            return {"per": default_pars["per"],
+                    "k": default_pars["k"],
+                    "e": default_pars["e"],
+                    "w": default_pars["w"],
+                    "tc": tc}
+
+        elif self.parameterisation == "per k ecosw esinw tp":
+            ecosw, esinw = self.convert_e_w_to_ecosw_esinw(default_pars["e"], default_pars["w"])
+            return {"per": default_pars["per"],
+                    "k": default_pars["k"],
+                    "ecosw": ecosw,
+                    "esinw": esinw,
+                    "tp": default_pars["tp"]}
+
+        elif self.parameterisation == "per k ecosw esinw tc":
+            ecosw, esinw = self.convert_e_w_to_ecosw_esinw(default_pars["e"], default_pars["w"])
+            tc = self.convert_tp_to_tc(default_pars["tp"], default_pars["per"],
+                                      default_pars["e"], default_pars["w"])
+            return {"per": default_pars["per"],
+                    "k": default_pars["k"],
+                    "ecosw": ecosw,
+                    "esinw": esinw,
+                    "tc": tc}
+
+        elif self.parameterisation == "per k secosw sesinw tp":
+            secosw, sesinw = self.convert_e_w_to_secosw_sesinw(default_pars["e"], default_pars["w"])
+            return {"per": default_pars["per"],
+                    "k": default_pars["k"],
+                    "secosw": secosw,
+                    "sesinw": sesinw,
+                    "tp": default_pars["tp"]}
+
+        elif self.parameterisation == "per k secosw sesinw tc":
+            secosw, sesinw = self.convert_e_w_to_secosw_sesinw(default_pars["e"], default_pars["w"])
+            tc = self.convert_tp_to_tc(default_pars["tp"], default_pars["per"],
+                                      default_pars["e"], default_pars["w"])
+            return {"per": default_pars["per"],
+                    "k": default_pars["k"],
+                    "secosw": secosw,
+                    "sesinw": sesinw,
+                    "tc": tc}
 
         else:
             raise ValueError(f"parameterisation {self.parameterisation} not recognised")

--- a/src/ravest/prior.py
+++ b/src/ravest/prior.py
@@ -1,9 +1,9 @@
 # prior.py
 import numpy as np
 from scipy.special import gammaln, xlog1py, xlogy
-from scipy.stats import truncnorm
+from scipy.stats import halfnorm, truncnorm
 
-PRIOR_FUNCTIONS = ["Uniform", "Gaussian", "EccentricityPrior", "TruncatedGaussian", "Beta"]
+PRIOR_FUNCTIONS = ["Uniform", "Gaussian", "EccentricityPrior", "TruncatedGaussian", "Beta", "HalfGaussian"]
 
 
 class Uniform:
@@ -215,3 +215,43 @@ class Beta:
 
     def __repr__(self):
         return f"Beta({self.a}, {self.b})"
+
+
+class HalfGaussian:
+    r"""Log of half-Gaussian prior distribution.
+
+    The log half-Gaussian prior function is defined as:
+    .. math::
+        \log \left( \frac{2}{\sigma \sqrt{2\pi}} \exp\left(-\frac{x^2}{2\sigma^2}\right) \right) \quad \text{for} \quad x \geq 0 \\
+        -\inf \quad \text{otherwise}
+
+    This is equivalent to a Gaussian distribution with mean=0 that has been
+    folded about zero (or truncated at zero with the remaining mass redistributed).
+
+    Commonly used for scale parameters that must be positive, such as
+    standard deviations, measurement uncertainties, or jitter terms.
+
+    Parameters
+    ----------
+    scale : float
+        Scale parameter σ (sigma) of the half-Gaussian distribution. Must be > 0.
+
+    Returns
+    -------
+    float
+        Logarithm of the prior probability density function.
+    """
+
+    def __init__(self, scale: float):
+        if scale <= 0:
+            raise ValueError(f"Scale parameter must be positive, got {scale}")
+        self.scale = float(scale)
+
+    def __call__(self, value):
+        if value < 0.0:
+            return -np.inf
+        else:
+            return halfnorm.logpdf(value, scale=self.scale)
+
+    def __repr__(self):
+        return f"HalfGaussian({self.scale})"

--- a/src/ravest/prior.py
+++ b/src/ravest/prior.py
@@ -13,7 +13,9 @@ class Uniform:
         -\log{b - a} \quad \text{for} \quad a \leq x \leq b \\
         -\inf \quad \text{otherwise} \\
 
-    Uses closed interval [a, b] - both boundary values are included.
+    Uses closed interval [a, b] - both boundary values are included. Note that
+    for usage on eccentricity, we recommend the half-open interval
+    EccentricityUniform prior instead.
 
     Parameters
     ----------
@@ -29,9 +31,14 @@ class Uniform:
     """
 
     def __init__(self, lower, upper):
+        if not np.isfinite(lower):
+            raise ValueError(f"Lower bound must be finite, got {lower}")
+        if not np.isfinite(upper):
+            raise ValueError(f"Upper bound must be finite, got {upper}")
+        if lower >= upper:
+            raise ValueError(f"Lower bound ({lower}) must be less than upper bound ({upper})")
         self.lower = lower
         self.upper = upper
-        # TODO: warnings if non-finite values?
 
     def __call__(self, value):
         if value < self.lower or value > self.upper:

--- a/tests/test_fit.py
+++ b/tests/test_fit.py
@@ -128,7 +128,7 @@ class TestFitter:
         priors = {"k_b": ravest.prior.Uniform(0, 20)}  # Missing jit prior
 
         fitter.params = params
-        with pytest.raises(ValueError, match="Missing priors for"):
+        with pytest.raises(ValueError, match="Missing priors for parameters.*jit"):
             fitter.priors = priors
 
     def test_add_priors_invalid_initial_value(self, test_circular_params, test_simple_priors):
@@ -155,7 +155,7 @@ class TestFitter:
             "per_b": ravest.prior.Uniform(1, 5),  # This is fixed!
         }
 
-        with pytest.raises(ValueError, match="Unexpected priors.*Expected 2 priors, got 3"):
+        with pytest.raises(ValueError, match="Unexpected priors.*per_b"):
             fitter.priors = priors
 
     def test_get_free_params(self, test_circular_params):

--- a/tests/test_parameterisation_flexibility.py
+++ b/tests/test_parameterisation_flexibility.py
@@ -1,0 +1,298 @@
+#!/usr/bin/env python3
+"""
+Test parameterisation flexibility - comprehensive test suite.
+"""
+
+import numpy as np
+import pytest
+
+from ravest.fit import Fitter
+from ravest.param import Parameter, Parameterisation
+from ravest.prior import Uniform
+
+
+class TestParameterisationFlexibility:
+    """Test parameterisation flexibility scenarios."""
+
+    def test_default_to_default_priors(self):
+        """Test default parameterisation with default priors."""
+        params = {
+            "per_b": Parameter(5.0, "days", fixed=False),
+            "k_b": Parameter(3.0, "m/s", fixed=False),
+            "e_b": Parameter(0.3, "", fixed=False),
+            "w_b": Parameter(np.radians(47), "rad", fixed=False),
+            "tp_b": Parameter(68.7, "days", fixed=False),
+            "g": Parameter(0.0, "m/s", fixed=True),
+            "gd": Parameter(0.0, "m/s/day", fixed=True),
+            "gdd": Parameter(0.0, "m/s/day^2", fixed=True),
+            "jit": Parameter(1.0, "m/s", fixed=False)
+        }
+        priors = {
+            "per_b": Uniform(0, 10),
+            "k_b": Uniform(0, 10),
+            "e_b": Uniform(0, 1),
+            "w_b": Uniform(-np.pi, np.pi),
+            "tp_b": Uniform(64, 70),
+            "jit": Uniform(0, 5)
+        }
+        fitter = Fitter(["b"], Parameterisation("per k e w tp"))
+        fitter.params = params
+        fitter.priors = priors
+        # Should not raise exception
+
+    def test_transformed_to_transformed_priors_secosw_sesinw(self):
+        """Test secosw/sesinw parameterisation with secosw/sesinw priors."""
+        params = {
+            "per_b": Parameter(5.0, "days", fixed=False),
+            "k_b": Parameter(3.0, "m/s", fixed=False),
+            "secosw_b": Parameter(0.3735, "", fixed=False),
+            "sesinw_b": Parameter(0.4006, "", fixed=False),
+            "tc_b": Parameter(69.0, "days", fixed=False),
+            "g": Parameter(0.0, "m/s", fixed=True),
+            "gd": Parameter(0.0, "m/s/day", fixed=True),
+            "gdd": Parameter(0.0, "m/s/day^2", fixed=True),
+            "jit": Parameter(1.0, "m/s", fixed=False)
+        }
+        priors = {
+            "per_b": Uniform(0, 10),
+            "k_b": Uniform(0, 10),
+            "secosw_b": Uniform(-1, 1),
+            "sesinw_b": Uniform(-1, 1),
+            "tc_b": Uniform(64, 70),
+            "jit": Uniform(0, 5)
+        }
+        fitter = Fitter(["b"], Parameterisation("per k secosw sesinw tc"))
+        fitter.params = params
+        fitter.priors = priors
+        # Should not raise exception
+
+    def test_transformed_to_transformed_priors_ecosw_esinw(self):
+        """Test ecosw/esinw parameterisation with ecosw/esinw priors."""
+        params = {
+            "per_b": Parameter(5.0, "days", fixed=False),
+            "k_b": Parameter(3.0, "m/s", fixed=False),
+            "ecosw_b": Parameter(0.1, "", fixed=False),
+            "esinw_b": Parameter(0.2, "", fixed=False),
+            "tc_b": Parameter(69.0, "days", fixed=False),
+            "g": Parameter(0.0, "m/s", fixed=True),
+            "gd": Parameter(0.0, "m/s/day", fixed=True),
+            "gdd": Parameter(0.0, "m/s/day^2", fixed=True),
+            "jit": Parameter(1.0, "m/s", fixed=False)
+        }
+        priors = {
+            "per_b": Uniform(0, 10),
+            "k_b": Uniform(0, 10),
+            "ecosw_b": Uniform(-1, 1),
+            "esinw_b": Uniform(-1, 1),
+            "tc_b": Uniform(64, 70),
+            "jit": Uniform(0, 5)
+        }
+        fitter = Fitter(["b"], Parameterisation("per k ecosw esinw tc"))
+        fitter.params = params
+        fitter.priors = priors
+        # Should not raise exception
+
+    def test_case3_secosw_sesinw_with_default_priors(self):
+        """Test secosw/sesinw parameterisation with default priors (Case 3)."""
+        params = {
+            "per_b": Parameter(5.0, "days", fixed=False),
+            "k_b": Parameter(3.0, "m/s", fixed=False),
+            "secosw_b": Parameter(0.3735, "", fixed=False),
+            "sesinw_b": Parameter(0.4006, "", fixed=False),
+            "tc_b": Parameter(69.0, "days", fixed=False),
+            "g": Parameter(0.0, "m/s", fixed=True),
+            "gd": Parameter(0.0, "m/s/day", fixed=True),
+            "gdd": Parameter(0.0, "m/s/day^2", fixed=True),
+            "jit": Parameter(1.0, "m/s", fixed=False)
+        }
+        priors = {
+            "per_b": Uniform(0, 10),
+            "k_b": Uniform(0, 10),
+            "e_b": Uniform(0, 1),           # Default equivalent to secosw/sesinw
+            "w_b": Uniform(-np.pi, np.pi),  # Default equivalent to secosw/sesinw
+            "tp_b": Uniform(64, 70),        # Default equivalent to tc
+            "jit": Uniform(0, 5)
+        }
+        fitter = Fitter(["b"], Parameterisation("per k secosw sesinw tc"))
+        fitter.params = params
+        fitter.priors = priors
+        # Should not raise exception
+
+    def test_case3_ecosw_esinw_with_default_priors(self):
+        """Test ecosw/esinw parameterisation with default priors (Case 3)."""
+        params = {
+            "per_b": Parameter(5.0, "days", fixed=False),
+            "k_b": Parameter(3.0, "m/s", fixed=False),
+            "ecosw_b": Parameter(0.1, "", fixed=False),
+            "esinw_b": Parameter(0.2, "", fixed=False),
+            "tc_b": Parameter(69.0, "days", fixed=False),
+            "g": Parameter(0.0, "m/s", fixed=True),
+            "gd": Parameter(0.0, "m/s/day", fixed=True),
+            "gdd": Parameter(0.0, "m/s/day^2", fixed=True),
+            "jit": Parameter(1.0, "m/s", fixed=False)
+        }
+        priors = {
+            "per_b": Uniform(0, 10),
+            "k_b": Uniform(0, 10),
+            "e_b": Uniform(0, 1),           # Default equivalent to ecosw/esinw
+            "w_b": Uniform(-np.pi, np.pi),  # Default equivalent to ecosw/esinw
+            "tp_b": Uniform(64, 70),        # Default equivalent to tc
+            "jit": Uniform(0, 5)
+        }
+        fitter = Fitter(["b"], Parameterisation("per k ecosw esinw tc"))
+        fitter.params = params
+        fitter.priors = priors
+        # Should not raise exception
+
+    def test_mixed_priors_per_parameter_flexibility(self):
+        """Test mixed priors (per-parameter flexibility)."""
+        params = {
+            "per_b": Parameter(5.0, "days", fixed=False),
+            "k_b": Parameter(3.0, "m/s", fixed=False),
+            "secosw_b": Parameter(0.3735, "", fixed=False),
+            "sesinw_b": Parameter(0.4006, "", fixed=False),
+            "tc_b": Parameter(69.0, "days", fixed=False),
+            "g": Parameter(0.0, "m/s", fixed=True),
+            "gd": Parameter(0.0, "m/s/day", fixed=True),
+            "gdd": Parameter(0.0, "m/s/day^2", fixed=True),
+            "jit": Parameter(1.0, "m/s", fixed=False)
+        }
+        priors = {
+            "per_b": Uniform(0, 10),        # Current parameterisation
+            "k_b": Uniform(0, 10),          # Current parameterisation
+            "e_b": Uniform(0, 1),           # Default equivalent to secosw/sesinw
+            "w_b": Uniform(-np.pi, np.pi),  # Default equivalent to secosw/sesinw
+            "tc_b": Uniform(64, 70),        # Current parameterisation
+            "jit": Uniform(0, 5)            # Current parameterisation
+        }
+        fitter = Fitter(["b"], Parameterisation("per k secosw sesinw tc"))
+        fitter.params = params
+        fitter.priors = priors
+        # Should not raise exception
+
+    def test_common_parameters_transformed_parameterisation(self):
+        """Test common parameters only with transformed parameterisation."""
+        params = {
+            "per_b": Parameter(5.0, "days", fixed=False),
+            "k_b": Parameter(3.0, "m/s", fixed=False),
+            "secosw_b": Parameter(0.3735, "", fixed=True),    # Fixed
+            "sesinw_b": Parameter(0.4006, "", fixed=True),    # Fixed
+            "tc_b": Parameter(69.0, "days", fixed=True),      # Fixed
+            "g": Parameter(0.0, "m/s", fixed=True),
+            "gd": Parameter(0.0, "m/s/day", fixed=True),
+            "gdd": Parameter(0.0, "m/s/day^2", fixed=True),
+            "jit": Parameter(1.0, "m/s", fixed=False)
+        }
+        priors = {
+            "per_b": Uniform(0, 10),
+            "k_b": Uniform(0, 10),
+            "jit": Uniform(0, 5)
+        }
+        fitter = Fitter(["b"], Parameterisation("per k secosw sesinw tc"))
+        fitter.params = params
+        fitter.priors = priors
+        # Should not raise exception
+
+    def test_common_parameters_default_parameterisation(self):
+        """Test common parameters only with default parameterisation."""
+        params = {
+            "per_b": Parameter(5.0, "days", fixed=False),
+            "k_b": Parameter(3.0, "m/s", fixed=False),
+            "e_b": Parameter(0.3, "", fixed=True),                # Fixed
+            "w_b": Parameter(np.radians(47), "rad", fixed=True),  # Fixed
+            "tp_b": Parameter(68.7, "days", fixed=True),          # Fixed
+            "g": Parameter(0.0, "m/s", fixed=True),
+            "gd": Parameter(0.0, "m/s/day", fixed=True),
+            "gdd": Parameter(0.0, "m/s/day^2", fixed=True),
+            "jit": Parameter(1.0, "m/s", fixed=False)
+        }
+        priors = {
+            "per_b": Uniform(0, 10),
+            "k_b": Uniform(0, 10),
+            "jit": Uniform(0, 5)
+        }
+        fitter = Fitter(["b"], Parameterisation("per k e w tp"))
+        fitter.params = params
+        fitter.priors = priors
+        # Should not raise exception
+
+    def test_mixed_secosw_sesinw_coupling_should_fail(self):
+        """Test that mixed secosw/sesinw coupling is rejected."""
+        params = {
+            "per_b": Parameter(5.0, "days", fixed=False),
+            "k_b": Parameter(3.0, "m/s", fixed=False),
+            "secosw_b": Parameter(0.3735, "", fixed=True),     # Fixed
+            "sesinw_b": Parameter(0.4006, "", fixed=False),    # Free - violation!
+            "tc_b": Parameter(69.0, "days", fixed=True),
+            "g": Parameter(0.0, "m/s", fixed=True),
+            "gd": Parameter(0.0, "m/s/day", fixed=True),
+            "gdd": Parameter(0.0, "m/s/day^2", fixed=True),
+            "jit": Parameter(1.0, "m/s", fixed=False)
+        }
+        fitter = Fitter(["b"], Parameterisation("per k secosw sesinw tc"))
+        with pytest.raises(ValueError, match="secosw_b and sesinw_b must both be fixed or both be free"):
+            fitter.params = params
+
+    def test_mixed_ecosw_esinw_coupling_should_fail(self):
+        """Test that mixed ecosw/esinw coupling is rejected."""
+        params = {
+            "per_b": Parameter(5.0, "days", fixed=False),
+            "k_b": Parameter(3.0, "m/s", fixed=False),
+            "ecosw_b": Parameter(0.1, "", fixed=True),      # Fixed
+            "esinw_b": Parameter(0.2, "", fixed=False),     # Free - violation!
+            "tc_b": Parameter(69.0, "days", fixed=True),
+            "g": Parameter(0.0, "m/s", fixed=True),
+            "gd": Parameter(0.0, "m/s/day", fixed=True),
+            "gdd": Parameter(0.0, "m/s/day^2", fixed=True),
+            "jit": Parameter(1.0, "m/s", fixed=False)
+        }
+        fitter = Fitter(["b"], Parameterisation("per k ecosw esinw tc"))
+        with pytest.raises(ValueError, match="ecosw_b and esinw_b must both be fixed or both be free"):
+            fitter.params = params
+
+    def test_missing_priors_should_fail(self):
+        """Test that missing priors are rejected."""
+        params = {
+            "per_b": Parameter(5.0, "days", fixed=False),
+            "k_b": Parameter(3.0, "m/s", fixed=False),
+            "e_b": Parameter(0.3, "", fixed=False),
+            "w_b": Parameter(np.radians(47), "rad", fixed=False),
+            "tp_b": Parameter(68.7, "days", fixed=False),
+            "g": Parameter(0.0, "m/s", fixed=True),
+            "gd": Parameter(0.0, "m/s/day", fixed=True),
+            "gdd": Parameter(0.0, "m/s/day^2", fixed=True),
+            "jit": Parameter(1.0, "m/s", fixed=False)
+        }
+        priors = {
+            "per_b": Uniform(0, 10),
+            "k_b": Uniform(0, 10),
+            # Missing e_b, w_b, tp_b, jit priors
+        }
+        fitter = Fitter(["b"], Parameterisation("per k e w tp"))
+        fitter.params = params
+        with pytest.raises(ValueError, match="Missing priors for parameters"):
+            fitter.priors = priors
+
+    def test_invalid_parameter_values_should_fail(self):
+        """Test that invalid parameter values are rejected."""
+        params = {
+            "per_b": Parameter(5.0, "days", fixed=False),
+            "k_b": Parameter(25.0, "m/s", fixed=False),     # Outside prior bounds [0, 20]
+            "e_b": Parameter(0.3, "", fixed=True),
+            "w_b": Parameter(np.radians(47), "rad", fixed=True),
+            "tp_b": Parameter(68.7, "days", fixed=False),
+            "g": Parameter(0.0, "m/s", fixed=True),
+            "gd": Parameter(0.0, "m/s/day", fixed=True),
+            "gdd": Parameter(0.0, "m/s/day^2", fixed=True),
+            "jit": Parameter(1.0, "m/s", fixed=False)
+        }
+        priors = {
+            "per_b": Uniform(0, 10),
+            "k_b": Uniform(0, 20),          # k_b = 25.0 is outside this range
+            "tp_b": Uniform(64, 70),
+            "jit": Uniform(0, 5)
+        }
+        fitter = Fitter(["b"], Parameterisation("per k e w tp"))
+        fitter.params = params
+        with pytest.raises(ValueError, match="Initial value 25.0 of parameter k_b is invalid for prior"):
+            fitter.priors = priors

--- a/tests/test_prior.py
+++ b/tests/test_prior.py
@@ -33,6 +33,48 @@ class TestUniform:
         assert prior(-1.0) == -np.inf  # Below lower bound
         assert prior(11.0) == -np.inf  # Above upper bound
 
+    def test_uniform_init_invalid_infinite_bounds(self):
+        """Test that infinite bounds raise ValueError"""
+        # Lower bound infinite
+        with pytest.raises(ValueError, match="Lower bound must be finite, got -inf"):
+            ravest.prior.Uniform(-np.inf, 10)
+
+        # Upper bound infinite
+        with pytest.raises(ValueError, match="Upper bound must be finite, got inf"):
+            ravest.prior.Uniform(0, np.inf)
+
+        # Both bounds infinite
+        with pytest.raises(ValueError, match="Lower bound must be finite, got -inf"):
+            ravest.prior.Uniform(-np.inf, np.inf)
+
+        # Both bounds same infinite value
+        with pytest.raises(ValueError, match="Lower bound must be finite, got inf"):
+            ravest.prior.Uniform(np.inf, np.inf)
+
+    def test_uniform_init_invalid_bounds_order(self):
+        """Test that lower >= upper raises ValueError"""
+        # Lower equals upper
+        with pytest.raises(ValueError, match="Lower bound \\(5.0\\) must be less than upper bound \\(5.0\\)"):
+            ravest.prior.Uniform(5.0, 5.0)
+
+        # Lower greater than upper
+        with pytest.raises(ValueError, match="Lower bound \\(10.0\\) must be less than upper bound \\(5.0\\)"):
+            ravest.prior.Uniform(10.0, 5.0)
+
+    def test_uniform_init_nan_bounds(self):
+        """Test that NaN bounds raise ValueError"""
+        # Lower bound NaN
+        with pytest.raises(ValueError, match="Lower bound must be finite, got nan"):
+            ravest.prior.Uniform(np.nan, 10)
+
+        # Upper bound NaN
+        with pytest.raises(ValueError, match="Upper bound must be finite, got nan"):
+            ravest.prior.Uniform(0, np.nan)
+
+        # Both bounds NaN
+        with pytest.raises(ValueError, match="Lower bound must be finite, got nan"):
+            ravest.prior.Uniform(np.nan, np.nan)
+
     def test_uniform_repr(self):
         """Test string representation"""
         prior = ravest.prior.Uniform(2.5, 7.5)

--- a/tests/test_prior.py
+++ b/tests/test_prior.py
@@ -80,52 +80,56 @@ class TestGaussian:
         assert repr(prior) == "Gaussian(1.5, 0.5)"
 
 
-class TestEccentricityPrior:
-    """Tests for the EccentricityPrior class"""
+class TestEccentricityUniform:
+    """Tests for the EccentricityUniform class"""
 
     def test_eccentricity_prior_init_valid(self):
         """Test valid initialization"""
-        prior = ravest.prior.EccentricityPrior(0.5)
+        prior = ravest.prior.EccentricityUniform(0.5)
         assert prior.upper == 0.5
+
+    def test_eccentricity_prior_init_valid_upper_one(self):
+        """Test that upper=1.0 is valid"""
+        prior = ravest.prior.EccentricityUniform(1.0)
+        assert prior.upper == 1.0
 
     def test_eccentricity_prior_init_invalid(self):
         """Test invalid initialization parameters"""
-        # Upper bound >= 1 should raise error
-        with pytest.raises(ValueError, match="Upper bound of eccentricity must be less than 1"):
-            ravest.prior.EccentricityPrior(1.0)
-
-        with pytest.raises(ValueError, match="Upper bound of eccentricity must be less than 1"):
-            ravest.prior.EccentricityPrior(1.5)
+        # Upper bound > 1 should raise error
+        with pytest.raises(ValueError, match="Upper bound of eccentricity must be less than or equal to 1"):
+            ravest.prior.EccentricityUniform(1.5)
 
         # Upper bound <= 0 should raise error
         with pytest.raises(ValueError, match="Upper bound of eccentricity must be greater than 0"):
-            ravest.prior.EccentricityPrior(0.0)
+            ravest.prior.EccentricityUniform(0.0)
 
         with pytest.raises(ValueError, match="Upper bound of eccentricity must be greater than 0"):
-            ravest.prior.EccentricityPrior(-0.1)
+            ravest.prior.EccentricityUniform(-0.1)
 
     def test_eccentricity_prior_valid_values(self):
         """Test log probability for valid eccentricity values"""
-        prior = ravest.prior.EccentricityPrior(0.8)
+        prior = ravest.prior.EccentricityUniform(0.8)
 
         # Inside bounds should return -log(upper)
         expected = -np.log(0.8)
         assert np.isclose(prior(0.0), expected)  # At zero (inclusive)
         assert np.isclose(prior(0.4), expected)  # Middle value
-        assert np.isclose(prior(0.8), expected)  # At upper bound
+        # Note: upper bound is excluded; half-open interval
 
     def test_eccentricity_prior_invalid_values(self):
         """Test log probability for invalid eccentricity values"""
-        prior = ravest.prior.EccentricityPrior(0.8)
+        prior = ravest.prior.EccentricityUniform(0.8)
 
         assert prior(-0.1) == -np.inf  # Below zero
+        assert prior(0.8) == -np.inf   # At upper bound (excluded)
         assert prior(0.9) == -np.inf   # Above upper bound
         assert prior(1.0) == -np.inf   # At 1.0
+        assert prior(1.5) == -np.inf   # Well above upper bound
 
     def test_eccentricity_prior_repr(self):
         """Test string representation"""
-        prior = ravest.prior.EccentricityPrior(0.7)
-        assert repr(prior) == "EccentricityPrior(0.7)"
+        prior = ravest.prior.EccentricityUniform(0.7)
+        assert repr(prior) == "EccentricityUniform(0.7)"
 
 
 class TestTruncatedGaussian:


### PR DESCRIPTION
* Added comprehensive astrophysical validity checks for all parameters, including checks for finite trend parameters and non-negative jitter, as well as explicit validation of parameter coupling constraints (e.g., `secosw`/`sesinw` and `ecosw`/`esinw` must both be fixed or both be free).
* Improved docstrings for parameter validation methods for clarity.

**Priors handling improvements:**

* Refactored Prior setters. Priors can now be defined in either the current or default parameterisation, detect and prevent conflicting priors (i.e. accidentally supplying both sets) and give clearer error messages for missing or unexpected priors. For example you may want to sample in $\sqrt{e}\cos{/omega}$ and $\sqrt{e}\sin{/omega}$, but have a prior defined directly on $e$ itself.
* Updated the `log_probability` method to automatically convert parameters to default parameteristaion for prior evaluation, when needed, and to fail gracefully if conversion is invalid.
* Added Half-Gaussian prior (potentially useful for jitter and eccentricity)
* EccentricityUniform prior now correctly has half-open interval. This is useful if you want to just set the upper cap to be 1, then now correctly $0\leq{e}<1$