### PR TITLE
Feature/logprob corrections per planet

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -27,6 +27,7 @@ autoapi/index
 :caption: Project
 
 FAQ.md
+logprob_corrections.md
 changelog.md
 contributing.md
 conduct.md

--- a/docs/logprob_corrections.md
+++ b/docs/logprob_corrections.md
@@ -1,0 +1,178 @@
+# Log-posterior corrections for the (secosw, sesinw) parameterisation
+
+## Overview
+
+When fitting radial velocity data in the transformed parameterisation
+
+```
+u = secosw = sqrt(e) * cos(w)
+v = sesinw = sqrt(e) * sin(w)
+```
+
+rather than sampling `(e, w)` directly, the log-posterior needs constant
+corrections so that Bayesian evidence (via nested sampling or the Learned
+Harmonic Mean Estimator, LHME, e.g. through the `harmonic` library) is
+coordinate-invariant. These corrections are constants, so they cancel in the
+Metropolis-Hastings acceptance ratio and have **no effect on MCMC parameter
+inference** - they only matter when computing an absolute evidence value.
+
+The inverse transform is `e = u^2 + v^2`, `w = atan2(v, u)`. The physical
+constraint `0 <= e < 1` is equivalent to the unit disc `u^2 + v^2 < 1`.
+
+## Per-planet classification
+
+Ravest classifies **each planet independently**, then sums the per-planet
+contributions. This matters for multi-planet systems where different planets
+may have priors defined in different coordinate systems (e.g. planet b's
+priors on `(u, v)`, planet c's priors on `(e, w)`) - each planet's correction
+depends only on its own parameterisation and prior choice, not on any other
+planet's.
+
+### CASE_1: default parameterisation, or transformed with this planet's secosw/sesinw fixed
+
+No transformation is in effect for this planet (either the whole fit uses
+the default `(e, w)` parameterisation, or this planet's `secosw`/`sesinw` are
+fixed rather than sampled). Contribution: `0`.
+
+### CASE_2: transformed, free secosw/sesinw, priors on (u, v)
+
+The sampler proposes `u` and `v` directly, and the priors are defined on `u`
+and `v` too - no Jacobian is needed since sampling and prior space coincide.
+However, the physical validity check truncates `(u, v)` to the unit disc.
+
+With `Uniform(-1, 1)` priors on both `u` and `v`, the joint prior density is
+`1/4` over the square `[-1,1] x [-1,1]` (area 4). Truncated to the unit disc
+(area `pi`), the prior integrates to `pi/4` instead of `1`. Renormalising
+requires multiplying by `4/pi`, i.e. adding `log(4/pi)` (~0.2416) in log
+space:
+
+```
+log_posterior = log_likelihood + log_prior_u(u) + log_prior_v(v) + log(4/pi)
+```
+
+Ravest only supports this case for `Uniform(-1, 1)` priors on both `u` and
+`v`. Any other prior shape on `(u, v)` would require computing
+
+```
+correction = -log( integral over u^2+v^2<1 of p_u(u) * p_v(v) du dv )
+```
+
+which has no closed form in general. **Ravest hard-raises
+`NotImplementedError`** if it encounters such a prior, directing the user to
+place their eccentricity belief on `e` instead (Case 3) - a separable,
+rotationally-symmetric prior on `(u, v)` is always re-expressible as a prior
+on `e` (e.g. iid Gaussians on `u` and `v` are exactly a `Rayleigh` prior on
+`e`, which Ravest ships directly), so this is not a loss of expressiveness.
+
+### CASE_3: transformed, free secosw/sesinw, priors on (e, w)
+
+The sampler proposes `u` and `v`, but the priors are defined on `e` and `w`.
+Evaluating the priors requires converting `e = u^2 + v^2`, `w = atan2(v, u)`,
+which is a change of variables and therefore needs a Jacobian correction:
+
+```
+J = | de/du   de/dv |   =   | 2u     2v  |
+    | dw/du   dw/dv |       | -v/e   u/e |
+
+det(J) = (2u)(u/e) - (2v)(-v/e) = 2(u^2 + v^2)/e = 2e/e = 2
+```
+
+So `|d(e,w)/d(u,v)| = 2`, giving a correction of `+log(2)` (~0.6931):
+
+```
+log_posterior = log_likelihood + log_prior_e(e(u,v)) + log_prior_w(w(u,v)) + log(2)
+```
+
+No renormalisation is needed here: the prior on `e` handles its own support
+(it returns `-inf` for `e >= 1`), so there is no external truncation, and the
+Jacobian is a purely geometric property of the coordinate mapping -
+independent of the prior shape. The same `+log(2)` applies whether the prior
+on `e` is `Uniform`, `HalfNormal`, `Rayleigh`, `VanEylen19Mixture`, `Beta`, or
+any other properly normalised distribution.
+
+### Sanity check
+
+With uniform priors (`e ~ Uniform(0,1)`, `w ~ Uniform(-pi, pi)`), the
+effective log-prior density inside the supported region is:
+
+- CASE_1: `log(1) + log(1/(2*pi)) = -log(2*pi)`
+- CASE_2: `log(1/4) + log(4/pi) = -log(pi)`
+- CASE_3: `log(1) + log(1/(2*pi)) + log(2) = -log(pi)`
+
+CASE_2 and CASE_3 agree with each other (as they must - both express the
+same physical prior on eccentricity, just in different coordinates). They
+differ from CASE_1 by `log(2)`, which is expected since CASE_1 lives in a
+different coordinate system.
+
+## Worked example: mixed two-planet system
+
+Consider a two-planet fit in the `(u, v)` parameterisation where planet b's
+eccentricity prior is `Uniform(-1, 1)` on both `secosw_b`/`sesinw_b` (CASE_2),
+and planet c's eccentricity prior is a `HalfNormal` on `e_c` with
+`Uniform(-pi, pi)` on `w_c` (CASE_3):
+
+```
+total correction = log(4/pi) + log(2) ~= 0.2416 + 0.6931 = 0.9347
+```
+
+A classifier that inspects the *whole system's* free parameters and priors
+in one pass (rather than per planet) cannot represent this: it would
+misclassify the system as globally CASE_2 or globally CASE_3 and apply the
+wrong per-planet constant (or the right constant to the wrong number of
+planets), producing a systematic ln(Z) error of ~0.45 for this two-planet
+example - far outside typical MCMC/LHME noise (~0.01). Classifying each
+planet independently and summing avoids this.
+
+## Implementation
+
+- `Parameterisation.log_jacobian_determinant()` (`src/ravest/param.py`)
+  returns `log(2)` for the `secosw`/`sesinw` parameterisation, `0.0`
+  otherwise.
+- `LogPosterior._classify_planet_case(letter)` classifies a single planet
+  into `CASE_1`/`CASE_2`/`CASE_3` (or raises `NotImplementedError` for
+  unsupported `(u, v)` priors).
+- `LogPosterior._compute_logprob_corrections()` loops over all planets,
+  classifies each, and sums the Jacobian and prior-renormalisation
+  contributions. These are computed once at construction time (they depend
+  only on the parameterisation, priors, and free/fixed status - all fixed at
+  construction) and stored as `_logprob_jacobian_correction`,
+  `_logprob_prior_renorm_correction`, and a per-planet
+  `_logprob_correction_breakdown` dict.
+- `LogPosterior.log_probability` adds both stored corrections to
+  `log_likelihood + log_prior` before returning.
+
+## ecosw/esinw retirement
+
+The `ecosw`/`esinw` parameterisation (`e cos w`, `e sin w`) has been disabled
+(removed from `ALLOWED_PARAMETERISATIONS`). Its Jacobian is
+`|d(e,w)/d(ecosw,esinw)| = 1/e`, which depends on the sample value and cannot
+be precomputed as a constant correction - exactly why the field moved to
+`secosw`/`sesinw` (whose Jacobian is the constant `2`) in the first place.
+Re-enabling it would require a per-sample Jacobian evaluation, which is
+outside the scope of this correction scheme.
+
+## Empirical validation
+
+The theory above was validated empirically (MCMC + `harmonic`/LHME evidence
+estimation on the K2-24 system) for each case in isolation, and for the
+mixed-case regression this fix addresses:
+
+- Case 3 vs Case 1 (uniform prior on e): evidence agrees within MCMC noise
+  once the `log(2)` correction is applied.
+- Case 2 vs Case 1 (Uniform(-1,1) priors on secosw/sesinw): evidence agrees
+  within MCMC noise once the `log(4/pi)` correction is applied.
+- Case 3 with a HalfNormal prior on e: confirms the Jacobian correction is
+  independent of the prior shape.
+- **Mixed two-planet case** (planet b Case 2, planet c Case 3, same fit):
+  `docs/Examples/test_mixed_case_corrections.ipynb` checks that per-planet
+  classification and summation recovers the correct combined correction
+  (`log(4/pi) + log(2)`) and that the resulting evidence agrees with a
+  reference fit sampled entirely in `(e, w)`.
+
+## Scope: GPFitter
+
+`GPFitter`/`GPLogPosterior` mirror `Fitter`/`LogPosterior` structurally but do
+not yet apply these corrections. Porting the fix there is deferred to a
+follow-up branch to keep this change reviewable. The correction values are
+unaffected by the likelihood function (GP or otherwise), since they depend
+only on the parameterisation and priors.

--- a/docs/logprob_corrections.md
+++ b/docs/logprob_corrections.md
@@ -140,6 +140,12 @@ planet independently and summing avoids this.
   `_logprob_correction_breakdown` dict.
 - `LogPosterior.log_probability` adds both stored corrections to
   `log_likelihood + log_prior` before returning.
+- `GPLogPosterior` mirrors `LogPosterior` exactly: the same
+  `_classify_planet_case`/`_compute_logprob_corrections` methods, and
+  `GPLogPosterior.log_probability` adds the same two stored corrections to
+  `log_likelihood + log_prior + log_hyperprior` before returning. The
+  corrections depend only on the parameterisation and priors, not the
+  likelihood, so no GP-specific logic is needed.
 
 ## ecosw/esinw retirement
 
@@ -164,15 +170,14 @@ mixed-case regression this fix addresses:
 - Case 3 with a HalfNormal prior on e: confirms the Jacobian correction is
   independent of the prior shape.
 - **Mixed two-planet case** (planet b Case 2, planet c Case 3, same fit):
-  `docs/Examples/test_mixed_case_corrections.ipynb` checks that per-planet
-  classification and summation recovers the correct combined correction
-  (`log(4/pi) + log(2)`) and that the resulting evidence agrees with a
+  per-planet classification and summation recovers the correct combined
+  correction (`log(4/pi) + log(2)`), and the resulting evidence agrees with a
   reference fit sampled entirely in `(e, w)`.
 
-## Scope: GPFitter
+## GPFitter
 
-`GPFitter`/`GPLogPosterior` mirror `Fitter`/`LogPosterior` structurally but do
-not yet apply these corrections. Porting the fix there is deferred to a
-follow-up branch to keep this change reviewable. The correction values are
-unaffected by the likelihood function (GP or otherwise), since they depend
-only on the parameterisation and priors.
+`GPFitter`/`GPLogPosterior` mirror `Fitter`/`LogPosterior` structurally, and
+apply the same per-planet corrections (see `tests/test_logprob_corrections_gp.py`
+for the mirrored unit-level coverage, including the mixed-case regression).
+The correction values are unaffected by the likelihood function (GP or
+otherwise), since they depend only on the parameterisation and priors.

--- a/docs/logprob_corrections.md
+++ b/docs/logprob_corrections.md
@@ -1,183 +1,125 @@
 # Log-posterior corrections for the (secosw, sesinw) parameterisation
 
-## Overview
+## You don't need to do anything
 
-When fitting radial velocity data in the transformed parameterisation
+Ravest applies these corrections **automatically**. They are computed once when
+the fit is set up (from your parameterisation, priors, and which parameters are
+free) and added inside the log-posterior during sampling. There is no knob to
+set and nothing to remember.
 
-```
-u = secosw = sqrt(e) * cos(w)
-v = sesinw = sqrt(e) * sin(w)
-```
+They also have **no effect on parameter inference**. The corrections are
+constants, so they cancel in the sampler's acceptance ratio - Ravest uses
+emcee's affine-invariant stretch move, in which any constant factor in the prior
+cancels identically, just as it does in a Metropolis-Hastings ratio. If you only
+care about parameter estimates and their uncertainties, you can ignore this page
+entirely.
 
-rather than sampling `(e, w)` directly, the log-posterior needs constant
-corrections so that Bayesian evidence (via nested sampling or the Learned
-Harmonic Mean Estimator, LHME, e.g. through the `harmonic` library) is
-coordinate-invariant. These corrections are constants, so they cancel in the
-Metropolis-Hastings acceptance ratio and have **no effect on MCMC parameter
-inference** - they only matter when computing an absolute evidence value.
+The corrections matter in exactly one situation: **Bayesian model comparison**,
+where you use the posterior chains to estimate an evidence `ln(Z)` (for example
+with the Learned Harmonic Mean Estimator, LHME, via the `harmonic` library). The
+evidence is an integral of the likelihood against the prior, so the prior must be
+correctly normalised in the space you actually sample in - otherwise the evidence
+for that model is systematically biased and comparisons against other models are
+unfair. Ravest handles this for you.
 
-The inverse transform is `e = u^2 + v^2`, `w = atan2(v, u)`. The physical
-constraint `0 <= e < 1` is equivalent to the unit disc `u^2 + v^2 < 1`.
+For the full derivation, see Appendix B of Dobson et al. (in prep.); this page is
+a practical summary.
 
-## Per-planet classification
+## The one choice that is yours
 
-Ravest classifies **each planet independently**, then sums the per-planet
-contributions. This matters for multi-planet systems where different planets
-may have priors defined in different coordinate systems (e.g. planet b's
-priors on `(u, v)`, planet c's priors on `(e, w)`) - each planet's correction
-depends only on its own parameterisation and prior choice, not on any other
-planet's.
+When you sample in the `(secosw, sesinw)` parameterisation, define your
+eccentricity belief as a prior on **`e`** (Case 3 below), using one of Ravest's
+eccentricity priors (`HalfNormal`, `Rayleigh`, `VanEylen19Mixture`, `Beta`,
+`EccentricityUniform`, `TruncatedNormal`). The only prior on `(secosw, sesinw)`
+directly that Ravest can normalise is `Uniform(-1, 1)` on both (Case 2); any
+other prior on `(secosw, sesinw)` raises `NotImplementedError`, because its
+renormalisation over the unit disc has no closed form in general. A separable,
+rotationally-symmetric belief on `(secosw, sesinw)` can (probably) always be
+re-expressed as a prior on `e` , yet you can still sample in `(secosw,sesinw)`
+to speed up MCMC converge and avoid the Lucy--Sweeney bias.
 
-### CASE_1: default parameterisation, or transformed with this planet's secosw/sesinw fixed
+## Background
 
-No transformation is in effect for this planet (either the whole fit uses
-the default `(e, w)` parameterisation, or this planet's `secosw`/`sesinw` are
-fixed rather than sampled). Contribution: `0`.
-
-### CASE_2: transformed, free secosw/sesinw, priors on (u, v)
-
-The sampler proposes `u` and `v` directly, and the priors are defined on `u`
-and `v` too - no Jacobian is needed since sampling and prior space coincide.
-However, the physical validity check truncates `(u, v)` to the unit disc.
-
-With `Uniform(-1, 1)` priors on both `u` and `v`, the joint prior density is
-`1/4` over the square `[-1,1] x [-1,1]` (area 4). Truncated to the unit disc
-(area `pi`), the prior integrates to `pi/4` instead of `1`. Renormalising
-requires multiplying by `4/pi`, i.e. adding `log(4/pi)` (~0.2416) in log
-space:
+In the transformed parameterisation
 
 ```
-log_posterior = log_likelihood + log_prior_u(u) + log_prior_v(v) + log(4/pi)
+u = "secosw" = sqrt(e) * cos(w)
+v = "sesinw" = sqrt(e) * sin(w)
 ```
 
-Ravest only supports this case for `Uniform(-1, 1)` priors on both `u` and
-`v`. Any other prior shape on `(u, v)` would require computing
+the inverse transform is `e = u^2 + v^2`, `w = atan2(v, u)`, and the physical
+constraint that `0 <= e < 1` is exactly the unit disc formed by `u^2 + v^2 < 1`.
+
+Ravest classifies **each planet independently** and sums the per-planet
+corrections. This matters for multi-planet systems, where different planets can
+have priors in different coordinate systems (e.g. planet b on `(u, v)`, planet c
+on `(e, w)`); each planet's correction depends only on its own choice.
+
+## The three cases for sampling eccentricity as a free parameter
+
+| Case | Sampling | Eccentricity prior | Correction (per planet) |
+|------|----------|--------------------|-------------------------|
+| 1 | `(e, w)` | any | `0` |
+| 2 | `(u, v)`, priors on `(u, v)` | `Uniform(-1, 1)` on both | `+log(4/pi) ~= +0.242` |
+| 3 | `(u, v)`, priors on `(e, w)` | any properly normalised prior on `e` | `+log(2) ~= +0.693` |
+
+**Case 1** needs no correction: sampling and prior space coincide, and the prior
+on `e` is already normalised over `[0, 1)` (provided you are using a proper prior...)
+
+**Case 2** arises because `Uniform(-1, 1)` on each of `u` and `v` has joint
+density `1/4` over the square `[-1, 1]^2` (area 4), but the physical validity
+check `u^2 + v^2 < 1` truncates the support to the unit disc (area `pi`).
+The prior then integrates to `pi/4` rather than `1`, so renormalising adds the 'missing'
+`log(4/pi)` to the log-posterior to ensure all priors are normalised properly.
+
+**Case 3** arises because the sampler proposes `(u, v)` but the prior is defined
+on `(e, w)`, so evaluating it is a change of variables. The Jacobian determinant
+of the `(u, v)` -> `(e, w)` mapping is the constant `2`, giving `+log(2)`. Being
+purely geometric, it is independent of the prior shape - the same `+log(2)`
+applies whether the prior on `e` is `Uniform`, `HalfNormal`, `Rayleigh`,
+`VanEylen19Mixture`, `Beta`, or anything else, provided it is properly normalised
+and truncated to `[0, 1)`.
+
+## Multi-planet systems
+
+Because classification is per-planet, the total correction to the log-prior
+(and therefore log-posterior) is the sum of the per-planet contributions.
+For a two-planet fit where planet b has `Uniform(-1, 1)` priors on
+`(secosw_b, sesinw_b)` (Case 2) and planet c has a `HalfNormal` on `e_c` with
+`Uniform(-pi, pi)` on `w_c` (Case 3):
 
 ```
-correction = -log( integral over u^2+v^2<1 of p_u(u) * p_v(v) du dv )
+total correction = log(4/pi) + log(2) ~= 0.242 + 0.693 = 0.935
 ```
 
-which has no closed form in general. **Ravest hard-raises
-`NotImplementedError`** if it encounters such a prior, directing the user to
-place their eccentricity belief on `e` instead (Case 3) - a separable,
-rotationally-symmetric prior on `(u, v)` is always re-expressible as a prior
-on `e` (e.g. iid Gaussians on `u` and `v` are exactly a `Rayleigh` prior on
-`e`, which Ravest ships directly), so this is not a loss of expressiveness.
+Classifying the system as a whole rather than per planet would apply the wrong
+constant (or the right one to the wrong number of planets), so Ravest always
+classifies each planet independently and sums.
 
-### CASE_3: transformed, free secosw/sesinw, priors on (e, w)
+## The ecosw/esinw parameterisation is disabled
 
-The sampler proposes `u` and `v`, but the priors are defined on `e` and `w`.
-Evaluating the priors requires converting `e = u^2 + v^2`, `w = atan2(v, u)`,
-which is a change of variables and therefore needs a Jacobian correction:
+The `ecosw`/`esinw` parameterisation (`e cos w`, `e sin w`) is not available
+(removed from `ALLOWED_PARAMETERISATIONS`). Its Jacobian is `1/e`, which depends
+on the sample value and so cannot be precomputed as a constant correction - it
+would need a per-sample evaluation during sampling, outside the scope of this
+scheme. This is precisely why most people sample in `secosw`/`sesinw`, whose
+Jacobian is the constant `2` (and avoids inducing an accidental prior on `e`.)
 
-```
-J = | de/du   de/dv |   =   | 2u     2v  |
-    | dw/du   dw/dv |       | -v/e   u/e |
+I really can't think of a reason you would want to sample in `ecosw/esinw` rather
+than `secosw/sesinw` -- if you want a prior to incentivise lower values of `e`,
+just fit in `secosw/sesinw` and use something like a `HalfNormal` prior on `e`
+instead.
 
-det(J) = (2u)(u/e) - (2v)(-v/e) = 2(u^2 + v^2)/e = 2e/e = 2
-```
+## Implementation and validation
 
-So `|d(e,w)/d(u,v)| = 2`, giving a correction of `+log(2)` (~0.6931):
+The corrections live in `LogPosterior` (and mirrored in `GPLogPosterior`) in
+`src/ravest/fit.py`: `_compute_logprob_corrections` classifies each planet and
+sums the contributions at construction time, and `log_probability` adds the
+stored total. The Jacobian value comes from
+`Parameterisation.log_jacobian_determinant` in `src/ravest/param.py`. The
+corrections depend only on the parameterisation and priors, not the likelihood,
+so `GPFitter` uses the same values.
 
-```
-log_posterior = log_likelihood + log_prior_e(e(u,v)) + log_prior_w(w(u,v)) + log(2)
-```
-
-No renormalisation is needed here: the prior on `e` handles its own support
-(it returns `-inf` for `e >= 1`), so there is no external truncation, and the
-Jacobian is a purely geometric property of the coordinate mapping -
-independent of the prior shape. The same `+log(2)` applies whether the prior
-on `e` is `Uniform`, `HalfNormal`, `Rayleigh`, `VanEylen19Mixture`, `Beta`, or
-any other properly normalised distribution.
-
-### Sanity check
-
-With uniform priors (`e ~ Uniform(0,1)`, `w ~ Uniform(-pi, pi)`), the
-effective log-prior density inside the supported region is:
-
-- CASE_1: `log(1) + log(1/(2*pi)) = -log(2*pi)`
-- CASE_2: `log(1/4) + log(4/pi) = -log(pi)`
-- CASE_3: `log(1) + log(1/(2*pi)) + log(2) = -log(pi)`
-
-CASE_2 and CASE_3 agree with each other (as they must - both express the
-same physical prior on eccentricity, just in different coordinates). They
-differ from CASE_1 by `log(2)`, which is expected since CASE_1 lives in a
-different coordinate system.
-
-## Worked example: mixed two-planet system
-
-Consider a two-planet fit in the `(u, v)` parameterisation where planet b's
-eccentricity prior is `Uniform(-1, 1)` on both `secosw_b`/`sesinw_b` (CASE_2),
-and planet c's eccentricity prior is a `HalfNormal` on `e_c` with
-`Uniform(-pi, pi)` on `w_c` (CASE_3):
-
-```
-total correction = log(4/pi) + log(2) ~= 0.2416 + 0.6931 = 0.9347
-```
-
-A classifier that inspects the *whole system's* free parameters and priors
-in one pass (rather than per planet) cannot represent this: it would
-misclassify the system as globally CASE_2 or globally CASE_3 and apply the
-wrong per-planet constant (or the right constant to the wrong number of
-planets), producing a systematic ln(Z) error of ~0.45 for this two-planet
-example - far outside typical MCMC/LHME noise (~0.01). Classifying each
-planet independently and summing avoids this.
-
-## Implementation
-
-- `Parameterisation.log_jacobian_determinant()` (`src/ravest/param.py`)
-  returns `log(2)` for the `secosw`/`sesinw` parameterisation, `0.0`
-  otherwise.
-- `LogPosterior._classify_planet_case(letter)` classifies a single planet
-  into `CASE_1`/`CASE_2`/`CASE_3` (or raises `NotImplementedError` for
-  unsupported `(u, v)` priors).
-- `LogPosterior._compute_logprob_corrections()` loops over all planets,
-  classifies each, and sums the Jacobian and prior-renormalisation
-  contributions. These are computed once at construction time (they depend
-  only on the parameterisation, priors, and free/fixed status - all fixed at
-  construction) and stored as `_logprob_jacobian_correction`,
-  `_logprob_prior_renorm_correction`, and a per-planet
-  `_logprob_correction_breakdown` dict.
-- `LogPosterior.log_probability` adds both stored corrections to
-  `log_likelihood + log_prior` before returning.
-- `GPLogPosterior` mirrors `LogPosterior` exactly: the same
-  `_classify_planet_case`/`_compute_logprob_corrections` methods, and
-  `GPLogPosterior.log_probability` adds the same two stored corrections to
-  `log_likelihood + log_prior + log_hyperprior` before returning. The
-  corrections depend only on the parameterisation and priors, not the
-  likelihood, so no GP-specific logic is needed.
-
-## ecosw/esinw retirement
-
-The `ecosw`/`esinw` parameterisation (`e cos w`, `e sin w`) has been disabled
-(removed from `ALLOWED_PARAMETERISATIONS`). Its Jacobian is
-`|d(e,w)/d(ecosw,esinw)| = 1/e`, which depends on the sample value and cannot
-be precomputed as a constant correction - exactly why the field moved to
-`secosw`/`sesinw` (whose Jacobian is the constant `2`) in the first place.
-Re-enabling it would require a per-sample Jacobian evaluation, which is
-outside the scope of this correction scheme.
-
-## Empirical validation
-
-The theory above was validated empirically (MCMC + `harmonic`/LHME evidence
-estimation on the K2-24 system) for each case in isolation, and for the
-mixed-case regression this fix addresses:
-
-- Case 3 vs Case 1 (uniform prior on e): evidence agrees within MCMC noise
-  once the `log(2)` correction is applied.
-- Case 2 vs Case 1 (Uniform(-1,1) priors on secosw/sesinw): evidence agrees
-  within MCMC noise once the `log(4/pi)` correction is applied.
-- Case 3 with a HalfNormal prior on e: confirms the Jacobian correction is
-  independent of the prior shape.
-- **Mixed two-planet case** (planet b Case 2, planet c Case 3, same fit):
-  per-planet classification and summation recovers the correct combined
-  correction (`log(4/pi) + log(2)`), and the resulting evidence agrees with a
-  reference fit sampled entirely in `(e, w)`.
-
-## GPFitter
-
-`GPFitter`/`GPLogPosterior` mirror `Fitter`/`LogPosterior` structurally, and
-apply the same per-planet corrections (see `tests/test_logprob_corrections_gp.py`
-for the mirrored unit-level coverage, including the mixed-case regression).
-The correction values are unaffected by the likelihood function (GP or
-otherwise), since they depend only on the parameterisation and priors.
+The corrections were validated against `harmonic`/LHME evidence estimates on the
+K2-24 system for each case in isolation and for the mixed two-planet case; details
+to be released as part of a paper featuring Ravest soon.

--- a/src/ravest/fit.py
+++ b/src/ravest/fit.py
@@ -33,6 +33,7 @@ import ravest.model
 from ravest.gp import GPKernel
 from ravest.model import _njit_kepler_rv
 from ravest.param import Parameter, Parameterisation, param_key_to_latex
+from ravest.prior import Uniform
 
 # Enable 64-bit precision for better numerical accuracy
 jax.config.update("jax_enable_x64", True)
@@ -3129,6 +3130,105 @@ class LogPosterior:
         )
         self.log_prior = LogPrior(self.priors)
 
+        (
+            self._logprob_jacobian_correction,
+            self._logprob_prior_renorm_correction,
+            self._logprob_correction_breakdown,
+        ) = self._compute_logprob_corrections()
+
+    def _classify_planet_case(self, letter: str) -> str:
+        """Classify a single planet's log-posterior correction case.
+
+        Parameters
+        ----------
+        letter : str
+            Single-character planet identifier.
+
+        Returns
+        -------
+        str
+            One of "CASE_1", "CASE_2", "CASE_3".
+
+        Raises
+        ------
+        NotImplementedError
+            If the planet has a prior on (secosw, sesinw) that is not both
+            Uniform(-1, 1) - such priors are unsupported; express the
+            eccentricity belief on (e, w) instead.
+        RuntimeError
+            If neither a (secosw, sesinw) nor an (e, w) prior pair is found
+            for this planet (should be unreachable given prior validation).
+        """
+        if self.parameterisation.log_jacobian_determinant() == 0.0:
+            return "CASE_1"
+
+        if f"secosw_{letter}" not in self.free_params_names:
+            # secosw/sesinw are fixed for this planet (coupling enforced at
+            # Fitter._validate_parameter_coupling)
+            return "CASE_1"
+
+        secosw_key, sesinw_key = f"secosw_{letter}", f"sesinw_{letter}"
+        e_key, w_key = f"e_{letter}", f"w_{letter}"
+
+        if secosw_key in self.priors and sesinw_key in self.priors:
+            secosw_prior = self.priors[secosw_key]
+            sesinw_prior = self.priors[sesinw_key]
+            if (
+                isinstance(secosw_prior, Uniform)
+                and isinstance(sesinw_prior, Uniform)
+                and secosw_prior.lower == -1
+                and secosw_prior.upper == 1
+                and sesinw_prior.lower == -1
+                and sesinw_prior.upper == 1
+            ):
+                return "CASE_2"
+            raise NotImplementedError(
+                f"Unsupported priors on (secosw_{letter}, sesinw_{letter}): "
+                f"{secosw_prior!r}, {sesinw_prior!r}. Only Uniform(-1, 1) priors "
+                "on (secosw, sesinw) are supported for evidence-correct log-posterior "
+                "corrections. A separable, rotationally-symmetric belief about "
+                "eccentricity can always be re-expressed as a prior on e instead - "
+                f"place priors on (e_{letter}, w_{letter}) using one of Ravest's "
+                "eccentricity priors (HalfNormal, Rayleigh, VanEylen19Mixture, Beta, "
+                "EccentricityUniform, TruncatedNormal)."
+            )
+        elif e_key in self.priors and w_key in self.priors:
+            return "CASE_3"
+        else:
+            raise RuntimeError(
+                f"Could not classify log-posterior correction case for planet "
+                f"'{letter}': no priors found on either (secosw, sesinw) or (e, w)."
+            )
+
+    def _compute_logprob_corrections(self) -> tuple[float, float, dict[str, dict]]:
+        """Compute per-planet log-posterior corrections, summed across planets.
+
+        Returns
+        -------
+        tuple[float, float, dict[str, dict]]
+            Total log-Jacobian correction, total log-prior-renormalisation
+            correction, and a per-planet breakdown of case/contributions.
+        """
+        log_jac = self.parameterisation.log_jacobian_determinant()
+        total_jacobian = 0.0
+        total_renorm = 0.0
+        breakdown: dict[str, dict] = {}
+
+        for letter in self.planet_letters:
+            case = self._classify_planet_case(letter)
+            jacobian = log_jac if case == "CASE_3" else 0.0
+            renorm = np.log(4.0 / np.pi) if case == "CASE_2" else 0.0
+
+            total_jacobian += jacobian
+            total_renorm += renorm
+            breakdown[letter] = {"case": case, "jacobian": jacobian, "renorm": renorm}
+            logging.info(
+                f"Planet {letter}: log-posterior correction case {case} "
+                f"(jacobian={jacobian}, renorm={renorm})"
+            )
+
+        return total_jacobian, total_renorm, breakdown
+
     def _convert_params_for_prior_evaluation(self, free_params_dict: dict[str, float]) -> Dict[str, float]:
         """Convert free parameters for prior evaluation if needed.
 
@@ -3217,8 +3317,14 @@ class LogPosterior:
         # Calculate log-likelihood with all parameters
         ll = self.log_likelihood(_all_params_for_ll)
 
-        # Return combined log-posterior (log-likelihood + log-prior)
+        # Return combined log-posterior (log-likelihood + log-prior), plus the
+        # constant per-planet Jacobian/prior-renormalisation corrections needed
+        # for evidence-correct (u, v) parameterisation sampling. These are
+        # constants so they cancel in the MCMC acceptance ratio and only
+        # matter for Bayesian evidence estimation (e.g. via harmonic/LHME).
         logprob = ll + lp
+        logprob += self._logprob_jacobian_correction
+        logprob += self._logprob_prior_renorm_correction
         return logprob
 
     def _negative_log_probability_for_MAP(self, free_params_vals: list[float]) -> float:

--- a/src/ravest/fit.py
+++ b/src/ravest/fit.py
@@ -7347,6 +7347,105 @@ class GPLogPosterior:
         self.log_prior = LogPrior(self.priors)
         self.log_hyperprior = LogPrior(self.hyperpriors)
 
+        (
+            self._logprob_jacobian_correction,
+            self._logprob_prior_renorm_correction,
+            self._logprob_correction_breakdown,
+        ) = self._compute_logprob_corrections()
+
+    def _classify_planet_case(self, letter: str) -> str:
+        """Classify a single planet's log-posterior correction case.
+
+        Parameters
+        ----------
+        letter : str
+            Single-character planet identifier.
+
+        Returns
+        -------
+        str
+            One of "CASE_1", "CASE_2", "CASE_3".
+
+        Raises
+        ------
+        NotImplementedError
+            If the planet has a prior on (secosw, sesinw) that is not both
+            Uniform(-1, 1) - such priors are unsupported; express the
+            eccentricity belief on (e, w) instead.
+        RuntimeError
+            If neither a (secosw, sesinw) nor an (e, w) prior pair is found
+            for this planet (should be unreachable given prior validation).
+        """
+        if self.parameterisation.log_jacobian_determinant() == 0.0:
+            return "CASE_1"
+
+        if f"secosw_{letter}" not in self.free_params_names:
+            # secosw/sesinw are fixed for this planet (coupling enforced at
+            # GPFitter._validate_parameter_coupling)
+            return "CASE_1"
+
+        secosw_key, sesinw_key = f"secosw_{letter}", f"sesinw_{letter}"
+        e_key, w_key = f"e_{letter}", f"w_{letter}"
+
+        if secosw_key in self.priors and sesinw_key in self.priors:
+            secosw_prior = self.priors[secosw_key]
+            sesinw_prior = self.priors[sesinw_key]
+            if (
+                isinstance(secosw_prior, Uniform)
+                and isinstance(sesinw_prior, Uniform)
+                and secosw_prior.lower == -1
+                and secosw_prior.upper == 1
+                and sesinw_prior.lower == -1
+                and sesinw_prior.upper == 1
+            ):
+                return "CASE_2"
+            raise NotImplementedError(
+                f"Unsupported priors on (secosw_{letter}, sesinw_{letter}): "
+                f"{secosw_prior!r}, {sesinw_prior!r}. Only Uniform(-1, 1) priors "
+                "on (secosw, sesinw) are supported for evidence-correct log-posterior "
+                "corrections. A separable, rotationally-symmetric belief about "
+                "eccentricity can always be re-expressed as a prior on e instead - "
+                f"place priors on (e_{letter}, w_{letter}) using one of Ravest's "
+                "eccentricity priors (HalfNormal, Rayleigh, VanEylen19Mixture, Beta, "
+                "EccentricityUniform, TruncatedNormal)."
+            )
+        elif e_key in self.priors and w_key in self.priors:
+            return "CASE_3"
+        else:
+            raise RuntimeError(
+                f"Could not classify log-posterior correction case for planet "
+                f"'{letter}': no priors found on either (secosw, sesinw) or (e, w)."
+            )
+
+    def _compute_logprob_corrections(self) -> tuple[float, float, dict[str, dict]]:
+        """Compute per-planet log-posterior corrections, summed across planets.
+
+        Returns
+        -------
+        tuple[float, float, dict[str, dict]]
+            Total log-Jacobian correction, total log-prior-renormalisation
+            correction, and a per-planet breakdown of case/contributions.
+        """
+        log_jac = self.parameterisation.log_jacobian_determinant()
+        total_jacobian = 0.0
+        total_renorm = 0.0
+        breakdown: dict[str, dict] = {}
+
+        for letter in self.planet_letters:
+            case = self._classify_planet_case(letter)
+            jacobian = log_jac if case == "CASE_3" else 0.0
+            renorm = np.log(4.0 / np.pi) if case == "CASE_2" else 0.0
+
+            total_jacobian += jacobian
+            total_renorm += renorm
+            breakdown[letter] = {"case": case, "jacobian": jacobian, "renorm": renorm}
+            logging.info(
+                f"Planet {letter}: log-posterior correction case {case} "
+                f"(jacobian={jacobian}, renorm={renorm})"
+            )
+
+        return total_jacobian, total_renorm, breakdown
+
     def _convert_params_for_prior_evaluation(self, free_params_dict: dict[str, float]) -> Dict[str, float]:
         """Convert free parameters for prior evaluation if needed.
 
@@ -7453,8 +7552,14 @@ class GPLogPosterior:
         all_hyperparams = self.fixed_hyperparams | free_hyperparams_dict
         ll = self.gp_log_likelihood(params=all_params, hyperparams=all_hyperparams)
 
-        # Return combined log-posterior (log-likelihood + log-prior + log-hyperprior)
+        # Return combined log-posterior (log-likelihood + log-prior + log-hyperprior),
+        # plus the constant per-planet Jacobian/prior-renormalisation corrections
+        # needed for evidence-correct (u, v) parameterisation sampling. These are
+        # constants so they cancel in the MCMC acceptance ratio and only matter
+        # for Bayesian evidence estimation (e.g. via harmonic/LHME).
         logprob = ll + lp + lhp
+        logprob += self._logprob_jacobian_correction
+        logprob += self._logprob_prior_renorm_correction
         return logprob
 
     def _negative_log_probability_for_MAP(self, combined_free_params_hyperparams_vals: list[float]) -> float:

--- a/src/ravest/param.py
+++ b/src/ravest/param.py
@@ -4,8 +4,8 @@ import numpy as np
 
 ALLOWED_PARAMETERISATIONS = ["P K e w Tp",   # default - the one used in Keplerian RV equation
                              "P K e w Tc",
-                             "P K ecosw esinw Tp",
-                             "P K ecosw esinw Tc",
+                             # "P K ecosw esinw Tp",  # DISABLED, LIKELY TO BE REMOVED
+                             # "P K ecosw esinw Tc",  # DISABLED, LIKELY TO BE REMOVED
                              "P K secosw sesinw Tp",
                              "P K secosw sesinw Tc"]
 
@@ -424,6 +424,15 @@ class Parameterisation:
 
         else:
             raise ValueError(f"parameterisation {self.parameterisation} not recognised")
+
+    def log_jacobian_determinant(self) -> float:
+        """Log absolute Jacobian determinant |d(e,w)/d(u,v)| for this parameterisation.
+
+        Returns log(2) for the secosw/sesinw parameterisation, else 0.0.
+        """
+        if "secosw" in self.parameterisation:
+            return np.log(2)
+        return 0.0
 
 
 def _instrument_subscript_latex(inst: str) -> str:

--- a/tests/test_logprob_corrections.py
+++ b/tests/test_logprob_corrections.py
@@ -1,0 +1,336 @@
+"""Test per-planet log-posterior corrections for the (u, v) parameterisation.
+
+These constants (Jacobian + prior-renormalisation corrections) make Bayesian
+evidence estimation (e.g. via harmonic/LHME) coordinate-invariant when sampling
+in the secosw/sesinw parameterisation. They cancel in the MCMC acceptance
+ratio, so they only matter for evidence, not parameter inference.
+"""
+import numpy as np
+import pytest
+
+from ravest.fit import Fitter, LogPosterior
+from ravest.param import Parameter, Parameterisation
+from ravest.prior import HalfNormal, Normal, Uniform
+
+LOG_4_OVER_PI = np.log(4.0 / np.pi)
+LOG_2 = np.log(2.0)
+
+
+def _build_log_posterior(fitter: Fitter) -> LogPosterior:
+    """Construct a LogPosterior from a configured Fitter.
+
+    Mirrors the construction sites inside Fitter (e.g. find_map_estimate).
+    """
+    return LogPosterior(
+        fitter.planet_letters,
+        fitter.parameterisation,
+        fitter.priors,
+        fitter.fixed_params_values_dict,
+        fitter.free_params_names,
+        fitter.time,
+        fitter.vel,
+        fitter.velerr,
+        fitter.instrument,
+        fitter.unique_instruments,
+        fitter.t0,
+    )
+
+
+@pytest.fixture
+def simple_test_data():
+    """Simple fake data, single instrument: HARPS."""
+    time = np.array([0.0, 1.0, 2.0, 3.0, 4.0])
+    vel = np.array([1.0, 2.0, 3.0, 2.0, 1.0])
+    velerr = np.array([0.5, 0.5, 0.5, 0.5, 0.5])
+    instrument = np.array(["HARPS", "HARPS", "HARPS", "HARPS", "HARPS"])
+    return time, vel, velerr, instrument
+
+
+def _common_params(letter: str, fixed: bool = False) -> dict:
+    return {
+        f"P_{letter}": Parameter(5.0, "days", fixed=False),
+        f"K_{letter}": Parameter(3.0, "m/s", fixed=False),
+        "g_HARPS": Parameter(0.0, "m/s", fixed=True),
+        "gd": Parameter(0.0, "m/s/day", fixed=True),
+        "gdd": Parameter(0.0, "m/s/day^2", fixed=True),
+        "jit_HARPS": Parameter(1.0, "m/s", fixed=False),
+    }
+
+
+def _common_priors() -> dict:
+    return {
+        "jit_HARPS": Uniform(0, 5),
+    }
+
+
+class TestSinglePlanetCases:
+    """Single-planet log-posterior correction cases."""
+
+    def test_default_parameterisation_is_case_1(self, simple_test_data) -> None:
+        """Default (e, w) parameterisation always classifies as CASE_1."""
+        time, vel, velerr, instrument = simple_test_data
+        params = _common_params("b") | {
+            "P_b": Parameter(5.0, "days", fixed=False),
+            "K_b": Parameter(3.0, "m/s", fixed=False),
+            "e_b": Parameter(0.0, "", fixed=False),
+            "w_b": Parameter(0.0, "rad", fixed=False),
+            "Tp_b": Parameter(0.0, "days", fixed=False),
+        }
+        priors = _common_priors() | {
+            "P_b": Uniform(0, 10),
+            "K_b": Uniform(0, 10),
+            "e_b": Uniform(0, 1),
+            "w_b": Uniform(-np.pi, np.pi),
+            "Tp_b": Uniform(-5, 5),
+        }
+        fitter = Fitter(["b"], Parameterisation("P K e w Tp"))
+        fitter.add_data(time=time, vel=vel, velerr=velerr, instrument=instrument, t0=2.0)
+        fitter.params = params
+        fitter.priors = priors
+
+        lp = _build_log_posterior(fitter)
+
+        assert lp._logprob_jacobian_correction == 0.0
+        assert lp._logprob_prior_renorm_correction == 0.0
+        assert lp._logprob_correction_breakdown["b"]["case"] == "CASE_1"
+
+    def test_transformed_with_fixed_secosw_sesinw_is_case_1(self, simple_test_data) -> None:
+        """Transformed parameterisation with fixed secosw/sesinw classifies as CASE_1."""
+        time, vel, velerr, instrument = simple_test_data
+        params = _common_params("b") | {
+            "secosw_b": Parameter(0.0, "", fixed=True),
+            "sesinw_b": Parameter(0.0, "", fixed=True),
+            "Tc_b": Parameter(0.0, "days", fixed=True),
+        }
+        priors = _common_priors() | {
+            "P_b": Uniform(0, 10),
+            "K_b": Uniform(0, 10),
+        }
+        fitter = Fitter(["b"], Parameterisation("P K secosw sesinw Tc"))
+        fitter.add_data(time=time, vel=vel, velerr=velerr, instrument=instrument, t0=2.0)
+        fitter.params = params
+        fitter.priors = priors
+
+        lp = _build_log_posterior(fitter)
+
+        assert lp._logprob_jacobian_correction == 0.0
+        assert lp._logprob_prior_renorm_correction == 0.0
+        assert lp._logprob_correction_breakdown["b"]["case"] == "CASE_1"
+
+    def test_transformed_with_uniform_uv_priors_is_case_2(self, simple_test_data) -> None:
+        """Transformed parameterisation with Uniform(-1, 1) (u, v) priors classifies as CASE_2."""
+        time, vel, velerr, instrument = simple_test_data
+        params = _common_params("b") | {
+            "secosw_b": Parameter(0.1, "", fixed=False),
+            "sesinw_b": Parameter(0.2, "", fixed=False),
+            "Tc_b": Parameter(2.0, "days", fixed=False),
+        }
+        priors = _common_priors() | {
+            "P_b": Uniform(0, 10),
+            "K_b": Uniform(0, 10),
+            "secosw_b": Uniform(-1, 1),
+            "sesinw_b": Uniform(-1, 1),
+            "Tc_b": Uniform(-5, 5),
+        }
+        fitter = Fitter(["b"], Parameterisation("P K secosw sesinw Tc"))
+        fitter.add_data(time=time, vel=vel, velerr=velerr, instrument=instrument, t0=2.0)
+        fitter.params = params
+        fitter.priors = priors
+
+        lp = _build_log_posterior(fitter)
+
+        assert lp._logprob_jacobian_correction == 0.0
+        assert np.isclose(lp._logprob_prior_renorm_correction, LOG_4_OVER_PI)
+        assert lp._logprob_correction_breakdown["b"]["case"] == "CASE_2"
+
+    @pytest.mark.parametrize("e_prior", [Uniform(0, 1), HalfNormal(0.3)])
+    def test_transformed_with_e_w_priors_is_case_3(self, simple_test_data, e_prior) -> None:
+        """Transformed parameterisation with (e, w) priors classifies as CASE_3, for any e prior."""
+        time, vel, velerr, instrument = simple_test_data
+        params = _common_params("b") | {
+            "secosw_b": Parameter(0.1, "", fixed=False),
+            "sesinw_b": Parameter(0.2, "", fixed=False),
+            "Tc_b": Parameter(2.0, "days", fixed=False),
+        }
+        priors = _common_priors() | {
+            "P_b": Uniform(0, 10),
+            "K_b": Uniform(0, 10),
+            "e_b": e_prior,
+            "w_b": Uniform(-np.pi, np.pi),
+            "Tp_b": Uniform(-5, 5),
+        }
+        fitter = Fitter(["b"], Parameterisation("P K secosw sesinw Tc"))
+        fitter.add_data(time=time, vel=vel, velerr=velerr, instrument=instrument, t0=2.0)
+        fitter.params = params
+        fitter.priors = priors
+
+        lp = _build_log_posterior(fitter)
+
+        assert np.isclose(lp._logprob_jacobian_correction, LOG_2)
+        assert lp._logprob_prior_renorm_correction == 0.0
+        assert lp._logprob_correction_breakdown["b"]["case"] == "CASE_3"
+
+
+class TestTwoPlanetCases:
+    """Two-planet log-posterior correction cases, including the mixed-case regression."""
+
+    def _two_planet_params_and_priors(self, secosw_priors: dict, e_priors: dict, letters: list[str]) -> tuple[dict, dict]:
+        params = {
+            "g_HARPS": Parameter(0.0, "m/s", fixed=True),
+            "gd": Parameter(0.0, "m/s/day", fixed=True),
+            "gdd": Parameter(0.0, "m/s/day^2", fixed=True),
+            "jit_HARPS": Parameter(1.0, "m/s", fixed=False),
+        }
+        priors = {"jit_HARPS": Uniform(0, 5)}
+
+        for letter in letters:
+            fixed = letter not in secosw_priors and letter not in e_priors
+            params[f"P_{letter}"] = Parameter(5.0, "days", fixed=False)
+            params[f"K_{letter}"] = Parameter(3.0, "m/s", fixed=False)
+            params[f"secosw_{letter}"] = Parameter(0.1, "", fixed=fixed)
+            params[f"sesinw_{letter}"] = Parameter(0.2, "", fixed=fixed)
+            params[f"Tc_{letter}"] = Parameter(2.0, "days", fixed=fixed)
+
+            priors[f"P_{letter}"] = Uniform(0, 10)
+            priors[f"K_{letter}"] = Uniform(0, 10)
+            if letter in secosw_priors:
+                priors[f"secosw_{letter}"] = Uniform(-1, 1)
+                priors[f"sesinw_{letter}"] = Uniform(-1, 1)
+                priors[f"Tc_{letter}"] = Uniform(-5, 5)
+            elif letter in e_priors:
+                priors[f"e_{letter}"] = Uniform(0, 1)
+                priors[f"w_{letter}"] = Uniform(-np.pi, np.pi)
+                priors[f"Tp_{letter}"] = Uniform(-5, 5)
+
+        return params, priors
+
+    def _build_fitter(self, simple_test_data, letters: list[str], params: dict, priors: dict) -> Fitter:
+        time, vel, velerr, instrument = simple_test_data
+        fitter = Fitter(letters, Parameterisation("P K secosw sesinw Tc"))
+        fitter.add_data(time=time, vel=vel, velerr=velerr, instrument=instrument, t0=2.0)
+        fitter.params = params
+        fitter.priors = priors
+        return fitter
+
+    def test_both_case_2(self, simple_test_data) -> None:
+        """Both planets in CASE_2 sums to 2 x log(4/pi)."""
+        params, priors = self._two_planet_params_and_priors(
+            secosw_priors={"b", "c"}, e_priors=set(), letters=["b", "c"]
+        )
+        fitter = self._build_fitter(simple_test_data, ["b", "c"], params, priors)
+
+        lp = _build_log_posterior(fitter)
+
+        assert lp._logprob_jacobian_correction == 0.0
+        assert np.isclose(lp._logprob_prior_renorm_correction, 2 * LOG_4_OVER_PI)
+
+    def test_both_case_3(self, simple_test_data) -> None:
+        """Both planets in CASE_3 sums to 2 x log(2)."""
+        params, priors = self._two_planet_params_and_priors(
+            secosw_priors=set(), e_priors={"b", "c"}, letters=["b", "c"]
+        )
+        fitter = self._build_fitter(simple_test_data, ["b", "c"], params, priors)
+
+        lp = _build_log_posterior(fitter)
+
+        assert np.isclose(lp._logprob_jacobian_correction, 2 * LOG_2)
+        assert lp._logprob_prior_renorm_correction == 0.0
+
+    def test_mixed_case_2_and_case_3_regression(self, simple_test_data) -> None:
+        """Regression test: planet b on (u,v) priors, planet c on (e,w) priors.
+
+        The stale prior implementation classified this globally via a single
+        set-equality over all free params, so a mixed system like this would
+        silently compute the wrong evidence correction. Each planet must be
+        classified independently and the contributions summed.
+        """
+        params, priors = self._two_planet_params_and_priors(
+            secosw_priors={"b"}, e_priors={"c"}, letters=["b", "c"]
+        )
+        fitter = self._build_fitter(simple_test_data, ["b", "c"], params, priors)
+
+        lp = _build_log_posterior(fitter)
+
+        assert np.isclose(lp._logprob_jacobian_correction, LOG_2)
+        assert np.isclose(lp._logprob_prior_renorm_correction, LOG_4_OVER_PI)
+        assert lp._logprob_correction_breakdown["b"]["case"] == "CASE_2"
+        assert lp._logprob_correction_breakdown["c"]["case"] == "CASE_3"
+
+    def test_mixed_case_1_fixed_and_case_2(self, simple_test_data) -> None:
+        """One planet fixed (CASE_1) and one in CASE_2 sums to only log(4/pi)."""
+        params, priors = self._two_planet_params_and_priors(
+            secosw_priors={"c"}, e_priors=set(), letters=["b", "c"]
+        )
+        fitter = self._build_fitter(simple_test_data, ["b", "c"], params, priors)
+
+        lp = _build_log_posterior(fitter)
+
+        assert lp._logprob_jacobian_correction == 0.0
+        assert np.isclose(lp._logprob_prior_renorm_correction, LOG_4_OVER_PI)
+        assert lp._logprob_correction_breakdown["b"]["case"] == "CASE_1"
+        assert lp._logprob_correction_breakdown["c"]["case"] == "CASE_2"
+
+    def test_mixed_case_1_fixed_and_case_3(self, simple_test_data) -> None:
+        """One planet fixed (CASE_1) and one in CASE_3 sums to only log(2)."""
+        params, priors = self._two_planet_params_and_priors(
+            secosw_priors=set(), e_priors={"c"}, letters=["b", "c"]
+        )
+        fitter = self._build_fitter(simple_test_data, ["b", "c"], params, priors)
+
+        lp = _build_log_posterior(fitter)
+
+        assert np.isclose(lp._logprob_jacobian_correction, LOG_2)
+        assert lp._logprob_prior_renorm_correction == 0.0
+        assert lp._logprob_correction_breakdown["b"]["case"] == "CASE_1"
+        assert lp._logprob_correction_breakdown["c"]["case"] == "CASE_3"
+
+
+class TestUnsupportedPriorRaises:
+    """Non-Uniform(-1, 1) priors on (secosw, sesinw) are unsupported and hard-raise."""
+
+    @pytest.mark.parametrize("secosw_prior, sesinw_prior", [
+        (Uniform(-0.5, 0.5), Uniform(-0.5, 0.5)),
+        (Normal(0, 0.3), Normal(0, 0.3)),
+    ])
+    def test_non_uniform_uv_prior_raises_not_implemented(self, simple_test_data, secosw_prior, sesinw_prior) -> None:
+        """Non-Uniform(-1, 1) priors on (secosw, sesinw) raise NotImplementedError."""
+        time, vel, velerr, instrument = simple_test_data
+        params = _common_params("b") | {
+            "secosw_b": Parameter(0.1, "", fixed=False),
+            "sesinw_b": Parameter(0.2, "", fixed=False),
+            "Tc_b": Parameter(2.0, "days", fixed=False),
+        }
+        priors = _common_priors() | {
+            "P_b": Uniform(0, 10),
+            "K_b": Uniform(0, 10),
+            "secosw_b": secosw_prior,
+            "sesinw_b": sesinw_prior,
+            "Tc_b": Uniform(-5, 5),
+        }
+        fitter = Fitter(["b"], Parameterisation("P K secosw sesinw Tc"))
+        fitter.add_data(time=time, vel=vel, velerr=velerr, instrument=instrument, t0=2.0)
+        fitter.params = params
+        fitter.priors = priors
+
+        with pytest.raises(NotImplementedError, match="e_b.*w_b"):
+            _build_log_posterior(fitter)
+
+
+class TestCorrectionBreakdown:
+    """Per-planet breakdown dict reports the right case and values sum to totals."""
+
+    def test_breakdown_sums_to_totals(self, simple_test_data) -> None:
+        """Per-planet breakdown values sum to the scalar total corrections."""
+        params, priors = TestTwoPlanetCases()._two_planet_params_and_priors(
+            secosw_priors={"b"}, e_priors={"c"}, letters=["b", "c"]
+        )
+        fitter = TestTwoPlanetCases()._build_fitter(simple_test_data, ["b", "c"], params, priors)
+
+        lp = _build_log_posterior(fitter)
+
+        breakdown = lp._logprob_correction_breakdown
+        assert set(breakdown.keys()) == {"b", "c"}
+        total_jacobian = sum(v["jacobian"] for v in breakdown.values())
+        total_renorm = sum(v["renorm"] for v in breakdown.values())
+        assert np.isclose(total_jacobian, lp._logprob_jacobian_correction)
+        assert np.isclose(total_renorm, lp._logprob_prior_renorm_correction)

--- a/tests/test_logprob_corrections_gp.py
+++ b/tests/test_logprob_corrections_gp.py
@@ -1,0 +1,209 @@
+"""Test per-planet log-posterior corrections for GPLogPosterior.
+
+Mirrors tests/test_logprob_corrections.py but for the GP-enabled log-posterior
+(GPLogPosterior), confirming the same per-planet Jacobian/prior-renormalisation
+corrections apply regardless of the likelihood function (GP or otherwise) -
+the corrections depend only on the parameterisation and priors.
+"""
+import numpy as np
+import pytest
+
+from ravest.fit import GPLogPosterior
+from ravest.gp import GPKernel
+from ravest.param import Parameterisation
+from ravest.prior import HalfNormal, Normal, Uniform
+
+LOG_4_OVER_PI = np.log(4.0 / np.pi)
+LOG_2 = np.log(2.0)
+
+
+@pytest.fixture
+def simple_gp_test_data():
+    """Simple fake data, single instrument: HARPS."""
+    time = np.array([0.0, 1.0, 2.0, 3.0, 4.0, 5.0])
+    vel = np.array([5.0, -2.0, -5.0, 2.0, 3.0, -1.0])
+    velerr = np.array([1.0, 1.1, 0.9, 0.85, 1.5, 1.0])
+    instrument = np.array(["HARPS", "HARPS", "HARPS", "HARPS", "HARPS", "HARPS"])
+    return time, vel, velerr, instrument
+
+
+def _gp_kernel() -> GPKernel:
+    return GPKernel("Quasiperiodic")
+
+
+def _fixed_hyperparams_and_priors() -> tuple[dict, dict]:
+    """All GP hyperparameters fixed.
+
+    Isolates the corrections under test from the (unrelated) GP likelihood machinery.
+    """
+    fixed_hyperparams = {
+        "gp_amp": 1.0,
+        "gp_lambda_e": 50.0,
+        "gp_lambda_p": 0.5,
+        "gp_period": 10.0,
+    }
+    return fixed_hyperparams, {}
+
+
+def _build_gp_log_posterior(
+    planet_letters: list[str],
+    parameterisation: Parameterisation,
+    priors: dict,
+    fixed_params: dict,
+    free_params_names: list[str],
+    data: tuple,
+) -> GPLogPosterior:
+    time, vel, velerr, instrument = data
+    fixed_hyperparams, hyperpriors = _fixed_hyperparams_and_priors()
+    return GPLogPosterior(
+        planet_letters=planet_letters,
+        parameterisation=parameterisation,
+        gp_kernel=_gp_kernel(),
+        priors=priors,
+        hyperpriors=hyperpriors,
+        fixed_params=fixed_params,
+        fixed_hyperparams=fixed_hyperparams,
+        free_params_names=free_params_names,
+        free_hyperparams_names=[],
+        time=time, vel=vel, velerr=velerr, t0=2.0,
+        instrument=instrument, unique_instruments=list(np.unique(instrument)),
+    )
+
+
+def _common_fixed_params(letter: str) -> dict:
+    return {
+        "g_HARPS": 0.0,
+        "gd": 0.0,
+        "gdd": 0.0,
+    }
+
+
+class TestSinglePlanetCasesGP:
+    """Single-planet log-posterior correction cases for GPLogPosterior."""
+
+    def test_default_parameterisation_is_case_1(self, simple_gp_test_data) -> None:
+        """Default (e, w) parameterisation always classifies as CASE_1."""
+        fixed_params = _common_fixed_params("b") | {
+            "P_b": 5.0, "e_b": 0.0, "w_b": 0.0, "Tp_b": 0.0, "jit_HARPS": 1.0,
+        }
+        priors = {"K_b": Uniform(0, 10)}
+        lp = _build_gp_log_posterior(
+            ["b"], Parameterisation("P K e w Tp"), priors, fixed_params, ["K_b"], simple_gp_test_data
+        )
+
+        assert lp._logprob_jacobian_correction == 0.0
+        assert lp._logprob_prior_renorm_correction == 0.0
+        assert lp._logprob_correction_breakdown["b"]["case"] == "CASE_1"
+
+    def test_transformed_with_fixed_secosw_sesinw_is_case_1(self, simple_gp_test_data) -> None:
+        """Transformed parameterisation with fixed secosw/sesinw classifies as CASE_1."""
+        fixed_params = _common_fixed_params("b") | {
+            "P_b": 5.0, "secosw_b": 0.0, "sesinw_b": 0.0, "Tc_b": 0.0, "jit_HARPS": 1.0,
+        }
+        priors = {"K_b": Uniform(0, 10)}
+        lp = _build_gp_log_posterior(
+            ["b"], Parameterisation("P K secosw sesinw Tc"), priors, fixed_params, ["K_b"], simple_gp_test_data
+        )
+
+        assert lp._logprob_jacobian_correction == 0.0
+        assert lp._logprob_prior_renorm_correction == 0.0
+        assert lp._logprob_correction_breakdown["b"]["case"] == "CASE_1"
+
+    def test_transformed_with_uniform_uv_priors_is_case_2(self, simple_gp_test_data) -> None:
+        """Transformed parameterisation with Uniform(-1, 1) (u, v) priors classifies as CASE_2."""
+        fixed_params = _common_fixed_params("b") | {"P_b": 5.0, "Tc_b": 2.0, "jit_HARPS": 1.0}
+        priors = {
+            "K_b": Uniform(0, 10),
+            "secosw_b": Uniform(-1, 1),
+            "sesinw_b": Uniform(-1, 1),
+        }
+        free_params_names = ["K_b", "secosw_b", "sesinw_b"]
+        lp = _build_gp_log_posterior(
+            ["b"], Parameterisation("P K secosw sesinw Tc"), priors, fixed_params, free_params_names, simple_gp_test_data
+        )
+
+        assert lp._logprob_jacobian_correction == 0.0
+        assert np.isclose(lp._logprob_prior_renorm_correction, LOG_4_OVER_PI)
+        assert lp._logprob_correction_breakdown["b"]["case"] == "CASE_2"
+
+    @pytest.mark.parametrize("e_prior", [Uniform(0, 1), HalfNormal(0.3)])
+    def test_transformed_with_e_w_priors_is_case_3(self, simple_gp_test_data, e_prior) -> None:
+        """Transformed parameterisation with (e, w) priors classifies as CASE_3, for any e prior."""
+        fixed_params = _common_fixed_params("b") | {"P_b": 5.0, "Tc_b": 2.0, "jit_HARPS": 1.0}
+        priors = {
+            "K_b": Uniform(0, 10),
+            "e_b": e_prior,
+            "w_b": Uniform(-np.pi, np.pi),
+        }
+        free_params_names = ["K_b", "secosw_b", "sesinw_b"]
+        lp = _build_gp_log_posterior(
+            ["b"], Parameterisation("P K secosw sesinw Tc"), priors, fixed_params, free_params_names, simple_gp_test_data
+        )
+
+        assert np.isclose(lp._logprob_jacobian_correction, LOG_2)
+        assert lp._logprob_prior_renorm_correction == 0.0
+        assert lp._logprob_correction_breakdown["b"]["case"] == "CASE_3"
+
+
+class TestMixedTwoPlanetCaseGP:
+    """Mixed two-planet regression test for GPLogPosterior."""
+
+    def test_mixed_case_2_and_case_3_regression(self, simple_gp_test_data) -> None:
+        """Planet b on (u, v) priors (CASE_2), planet c on (e, w) priors (CASE_3).
+
+        Confirms the per-planet classification and summation ported from
+        LogPosterior also holds for GPLogPosterior, since the corrections
+        depend only on the parameterisation and priors, not the likelihood.
+        """
+        fixed_params = {
+            "g_HARPS": 0.0, "gd": 0.0, "gdd": 0.0,
+            "P_b": 5.0, "Tc_b": 2.0,
+            "P_c": 8.0, "Tc_c": 3.0,
+        }
+        priors = {
+            "K_b": Uniform(0, 10),
+            "secosw_b": Uniform(-1, 1),
+            "sesinw_b": Uniform(-1, 1),
+            "K_c": Uniform(0, 10),
+            "e_c": Uniform(0, 1),
+            "w_c": Uniform(-np.pi, np.pi),
+            "jit_HARPS": Uniform(0, 5),
+        }
+        free_params_names = ["K_b", "secosw_b", "sesinw_b", "K_c", "secosw_c", "sesinw_c", "jit_HARPS"]
+        lp = _build_gp_log_posterior(
+            ["b", "c"], Parameterisation("P K secosw sesinw Tc"), priors, fixed_params, free_params_names, simple_gp_test_data
+        )
+
+        assert np.isclose(lp._logprob_jacobian_correction, LOG_2)
+        assert np.isclose(lp._logprob_prior_renorm_correction, LOG_4_OVER_PI)
+        assert lp._logprob_correction_breakdown["b"]["case"] == "CASE_2"
+        assert lp._logprob_correction_breakdown["c"]["case"] == "CASE_3"
+
+        breakdown = lp._logprob_correction_breakdown
+        total_jacobian = sum(v["jacobian"] for v in breakdown.values())
+        total_renorm = sum(v["renorm"] for v in breakdown.values())
+        assert np.isclose(total_jacobian, lp._logprob_jacobian_correction)
+        assert np.isclose(total_renorm, lp._logprob_prior_renorm_correction)
+
+
+class TestUnsupportedPriorRaisesGP:
+    """Non-Uniform(-1, 1) priors on (secosw, sesinw) are unsupported and hard-raise."""
+
+    @pytest.mark.parametrize("secosw_prior, sesinw_prior", [
+        (Uniform(-0.5, 0.5), Uniform(-0.5, 0.5)),
+        (Normal(0, 0.3), Normal(0, 0.3)),
+    ])
+    def test_non_uniform_uv_prior_raises_not_implemented(self, simple_gp_test_data, secosw_prior, sesinw_prior) -> None:
+        """Non-Uniform(-1, 1) priors on (secosw, sesinw) raise NotImplementedError."""
+        fixed_params = _common_fixed_params("b") | {"P_b": 5.0, "Tc_b": 2.0, "jit_HARPS": 1.0}
+        priors = {
+            "K_b": Uniform(0, 10),
+            "secosw_b": secosw_prior,
+            "sesinw_b": sesinw_prior,
+        }
+        free_params_names = ["K_b", "secosw_b", "sesinw_b"]
+
+        with pytest.raises(NotImplementedError, match="e_b.*w_b"):
+            _build_gp_log_posterior(
+                ["b"], Parameterisation("P K secosw sesinw Tc"), priors, fixed_params, free_params_names, simple_gp_test_data
+            )

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -451,20 +451,6 @@ def test_star_str_without_trend() -> None:
 class TestPlanetParameterisations:
     """Test Planet creation with different parameterisations."""
 
-    def test_planet_ecosw_esinw_tp(self) -> None:
-        """Test Planet with ecosw/esinw/Tp parameterisation."""
-        e, w = 0.3, 0.5
-        ecosw = e * np.cos(w)
-        esinw = e * np.sin(w)
-        planet = Planet(letter="b", parameterisation=Parameterisation("P K ecosw esinw Tp"),
-                        params={"P": 10.0, "K": 5.0, "ecosw": ecosw, "esinw": esinw, "Tp": 0.0})
-
-        # Should successfully compute RV
-        t = np.array([0.0, 2.5, 5.0])
-        rv = planet.radial_velocity(t)
-        assert np.all(np.isfinite(rv))
-        assert len(rv) == 3
-
     def test_planet_secosw_sesinw_tc(self) -> None:
         """Test Planet with secosw/sesinw/Tc parameterisation."""
         e, w = 0.2, 0.3
@@ -486,12 +472,6 @@ class TestPlanetParameterisations:
         planet_default = Planet(letter="b", parameterisation=Parameterisation("P K e w Tp"),
                                 params={"P": P, "K": K, "e": e, "w": w, "Tp": tp})
 
-        # ecosw/esinw parameterisation
-        ecosw = e * np.cos(w)
-        esinw = e * np.sin(w)
-        planet_ecosw = Planet(letter="b", parameterisation=Parameterisation("P K ecosw esinw Tp"),
-                              params={"P": P, "K": K, "ecosw": ecosw, "esinw": esinw, "Tp": tp})
-
         # secosw/sesinw parameterisation
         secosw = np.sqrt(e) * np.cos(w)
         sesinw = np.sqrt(e) * np.sin(w)
@@ -500,10 +480,8 @@ class TestPlanetParameterisations:
 
         t = np.linspace(0, 20, 100)
         rv_default = planet_default.radial_velocity(t)
-        rv_ecosw = planet_ecosw.radial_velocity(t)
         rv_secosw = planet_secosw.radial_velocity(t)
 
-        np.testing.assert_allclose(rv_ecosw, rv_default, atol=1e-10)
         np.testing.assert_allclose(rv_secosw, rv_default, atol=1e-10)
 
 

--- a/tests/test_param.py
+++ b/tests/test_param.py
@@ -33,27 +33,6 @@ def test_convert_e_w_to_ecosw_esinw(e, w) -> None:
     assert np.isclose(ecosw, expected_ecosw)
     assert np.isclose(esinw, expected_esinw)
 
-@pytest.mark.parametrize("ecosw, esinw", [
-    (ecosw, esinw) for ecosw in np.arange(0, 1, 0.1) for esinw in np.arange(0, 1, 0.1)
-    if np.sqrt(ecosw**2 + esinw**2) < 1.0  # Only test valid combinations where e < 1
-])
-def test_convert_ecosw_esinw_to_e_w_valid(ecosw, esinw) -> None:
-    para = Parameterisation("P K ecosw esinw Tp")
-    expected_e = np.sqrt(ecosw**2 + esinw**2)
-    expected_w = np.arctan2(esinw, ecosw)
-    e, w = para.convert_ecosw_esinw_to_e_w(ecosw, esinw)
-    assert np.isclose(e, expected_e)
-    assert np.isclose(w, expected_w)
-
-@pytest.mark.parametrize("ecosw, esinw", [
-    (ecosw, esinw) for ecosw in np.arange(0, 1, 0.1) for esinw in np.arange(0, 1, 0.1)
-    if np.sqrt(ecosw**2 + esinw**2) >= 1.0  # Test invalid combinations where e >= 1
-])
-def test_convert_ecosw_esinw_to_e_w_invalid(ecosw, esinw) -> None:
-    para = Parameterisation("P K ecosw esinw Tp")
-    with pytest.raises(ValueError, match="Invalid eccentricity.*>= 1.0"):
-        para.convert_ecosw_esinw_to_e_w(ecosw, esinw)
-
 @pytest.mark.parametrize("secosw, sesinw", [
     (secosw, sesinw) for secosw in np.arange(0, 1, 0.1) for sesinw in np.arange(0, 1, 0.1)
 ])
@@ -149,36 +128,6 @@ class TestConvertToDefault:
             np.testing.assert_allclose(result[key], _DEFAULT_PARAMS[key], atol=1e-10,
                                        err_msg=f"Mismatch on {key}")
 
-    def test_ecosw_esinw_tp_to_default(self) -> None:
-        """Test P K ecosw esinw Tp -> P K e w Tp."""
-        para = Parameterisation("P K ecosw esinw Tp")
-        ecosw = _DEFAULT_PARAMS["e"] * np.cos(_DEFAULT_PARAMS["w"])
-        esinw = _DEFAULT_PARAMS["e"] * np.sin(_DEFAULT_PARAMS["w"])
-        inpars = {"P": 10.0, "K": 25.0, "ecosw": ecosw, "esinw": esinw, "Tp": 5.0}
-
-        result = para.convert_pars_to_default_parameterisation(inpars)
-
-        np.testing.assert_allclose(result["e"], _DEFAULT_PARAMS["e"], atol=1e-10)
-        np.testing.assert_allclose(result["w"], _DEFAULT_PARAMS["w"], atol=1e-10)
-        assert result["Tp"] == _DEFAULT_PARAMS["Tp"]
-
-    def test_ecosw_esinw_tc_to_default(self) -> None:
-        """Test P K ecosw esinw Tc -> P K e w Tp."""
-        para = Parameterisation("P K ecosw esinw Tc")
-        para_default = Parameterisation("P K e w Tp")
-
-        ecosw = _DEFAULT_PARAMS["e"] * np.cos(_DEFAULT_PARAMS["w"])
-        esinw = _DEFAULT_PARAMS["e"] * np.sin(_DEFAULT_PARAMS["w"])
-        tc = para_default.convert_tp_to_tc(_DEFAULT_PARAMS["Tp"], _DEFAULT_PARAMS["P"],
-                                           _DEFAULT_PARAMS["e"], _DEFAULT_PARAMS["w"])
-        inpars = {"P": 10.0, "K": 25.0, "ecosw": ecosw, "esinw": esinw, "Tc": tc}
-
-        result = para.convert_pars_to_default_parameterisation(inpars)
-
-        np.testing.assert_allclose(result["e"], _DEFAULT_PARAMS["e"], atol=1e-10)
-        np.testing.assert_allclose(result["w"], _DEFAULT_PARAMS["w"], atol=1e-10)
-        np.testing.assert_allclose(result["Tp"], _DEFAULT_PARAMS["Tp"], atol=1e-10)
-
     def test_secosw_sesinw_tp_to_default(self) -> None:
         """Test P K secosw sesinw Tp -> P K e w Tp."""
         para = Parameterisation("P K secosw sesinw Tp")
@@ -229,30 +178,6 @@ class TestConvertFromDefault:
                                                      _DEFAULT_PARAMS["e"], _DEFAULT_PARAMS["w"])
         np.testing.assert_allclose(result["Tc"], expected_tc, atol=1e-10)
 
-    def test_default_to_ecosw_esinw_tp(self) -> None:
-        """Test default -> P K ecosw esinw Tp."""
-        para = Parameterisation("P K ecosw esinw Tp")
-
-        result = para.convert_pars_from_default_parameterisation(_DEFAULT_PARAMS)
-
-        expected_ecosw = _DEFAULT_PARAMS["e"] * np.cos(_DEFAULT_PARAMS["w"])
-        expected_esinw = _DEFAULT_PARAMS["e"] * np.sin(_DEFAULT_PARAMS["w"])
-        np.testing.assert_allclose(result["ecosw"], expected_ecosw, atol=1e-10)
-        np.testing.assert_allclose(result["esinw"], expected_esinw, atol=1e-10)
-        assert result["Tp"] == _DEFAULT_PARAMS["Tp"]
-
-    def test_default_to_ecosw_esinw_tc(self) -> None:
-        """Test default -> P K ecosw esinw Tc."""
-        para = Parameterisation("P K ecosw esinw Tc")
-
-        result = para.convert_pars_from_default_parameterisation(_DEFAULT_PARAMS)
-
-        expected_ecosw = _DEFAULT_PARAMS["e"] * np.cos(_DEFAULT_PARAMS["w"])
-        expected_esinw = _DEFAULT_PARAMS["e"] * np.sin(_DEFAULT_PARAMS["w"])
-        np.testing.assert_allclose(result["ecosw"], expected_ecosw, atol=1e-10)
-        np.testing.assert_allclose(result["esinw"], expected_esinw, atol=1e-10)
-        assert "Tc" in result
-
     def test_default_to_secosw_sesinw_tp(self) -> None:
         """Test default -> P K secosw sesinw Tp."""
         para = Parameterisation("P K secosw sesinw Tp")
@@ -292,8 +217,6 @@ class TestRoundTripConversions:
 
     @pytest.mark.parametrize("param_str", [
         "P K e w Tc",
-        "P K ecosw esinw Tp",
-        "P K ecosw esinw Tc",
         "P K secosw sesinw Tp",
         "P K secosw sesinw Tc",
     ])

--- a/tests/test_parameterisation_flexibility.py
+++ b/tests/test_parameterisation_flexibility.py
@@ -91,34 +91,6 @@ class TestParameterisationFlexibility:
         fitter.priors = priors
         # Should not raise exception
 
-    def test_transformed_to_transformed_priors_ecosw_esinw(self, simple_test_data) -> None:
-        """Test ecosw/esinw parameterisation with ecosw/esinw priors (single instrument: HARPS)."""
-        time, vel, velerr, instrument = simple_test_data
-        params = {
-            "P_b": Parameter(5.0, "days", fixed=False),
-            "K_b": Parameter(3.0, "m/s", fixed=False),
-            "ecosw_b": Parameter(0.1, "", fixed=False),
-            "esinw_b": Parameter(0.2, "", fixed=False),
-            "Tc_b": Parameter(69.0, "days", fixed=False),
-            "g_HARPS": Parameter(0.0, "m/s", fixed=True),
-            "gd": Parameter(0.0, "m/s/day", fixed=True),
-            "gdd": Parameter(0.0, "m/s/day^2", fixed=True),
-            "jit_HARPS": Parameter(1.0, "m/s", fixed=False)
-        }
-        priors = {
-            "P_b": Uniform(0, 10),
-            "K_b": Uniform(0, 10),
-            "ecosw_b": Uniform(-1, 1),
-            "esinw_b": Uniform(-1, 1),
-            "Tc_b": Uniform(64, 70),
-            "jit_HARPS": Uniform(0, 5)
-        }
-        fitter = Fitter(["b"], Parameterisation("P K ecosw esinw Tc"))
-        fitter.add_data(time=time, vel=vel, velerr=velerr, instrument=instrument, t0=2.0)
-        fitter.params = params
-        fitter.priors = priors
-        # Should not raise exception
-
     def test_case3_secosw_sesinw_with_default_priors(self, simple_test_data) -> None:
         """Test secosw/sesinw parameterisation with default priors (Case 3, single instrument: HARPS)."""
         time, vel, velerr, instrument = simple_test_data
@@ -142,34 +114,6 @@ class TestParameterisationFlexibility:
             "jit_HARPS": Uniform(0, 5)
         }
         fitter = Fitter(["b"], Parameterisation("P K secosw sesinw Tc"))
-        fitter.add_data(time=time, vel=vel, velerr=velerr, instrument=instrument, t0=2.0)
-        fitter.params = params
-        fitter.priors = priors
-        # Should not raise exception
-
-    def test_case3_ecosw_esinw_with_default_priors(self, simple_test_data) -> None:
-        """Test ecosw/esinw parameterisation with default priors (Case 3, single instrument: HARPS)."""
-        time, vel, velerr, instrument = simple_test_data
-        params = {
-            "P_b": Parameter(5.0, "days", fixed=False),
-            "K_b": Parameter(3.0, "m/s", fixed=False),
-            "ecosw_b": Parameter(0.1, "", fixed=False),
-            "esinw_b": Parameter(0.2, "", fixed=False),
-            "Tc_b": Parameter(69.0, "days", fixed=False),
-            "g_HARPS": Parameter(0.0, "m/s", fixed=True),
-            "gd": Parameter(0.0, "m/s/day", fixed=True),
-            "gdd": Parameter(0.0, "m/s/day^2", fixed=True),
-            "jit_HARPS": Parameter(1.0, "m/s", fixed=False)
-        }
-        priors = {
-            "P_b": Uniform(0, 10),
-            "K_b": Uniform(0, 10),
-            "e_b": Uniform(0, 1),           # Default equivalent to ecosw/esinw
-            "w_b": Uniform(-np.pi, np.pi),  # Default equivalent to ecosw/esinw
-            "Tp_b": Uniform(64, 70),        # Default equivalent to tc
-            "jit_HARPS": Uniform(0, 5)
-        }
-        fitter = Fitter(["b"], Parameterisation("P K ecosw esinw Tc"))
         fitter.add_data(time=time, vel=vel, velerr=velerr, instrument=instrument, t0=2.0)
         fitter.params = params
         fitter.priors = priors
@@ -270,25 +214,6 @@ class TestParameterisationFlexibility:
         fitter = Fitter(["b"], Parameterisation("P K secosw sesinw Tc"))
         fitter.add_data(time=time, vel=vel, velerr=velerr, instrument=instrument, t0=2.0)
         with pytest.raises(ValueError, match="secosw_b and sesinw_b must both be fixed or both be free"):
-            fitter.params = params
-
-    def test_mixed_ecosw_esinw_coupling_should_fail(self, simple_test_data) -> None:
-        """Test that mixed ecosw/esinw coupling is rejected (single instrument: HARPS)."""
-        time, vel, velerr, instrument = simple_test_data
-        params = {
-            "P_b": Parameter(5.0, "days", fixed=False),
-            "K_b": Parameter(3.0, "m/s", fixed=False),
-            "ecosw_b": Parameter(0.1, "", fixed=True),      # Fixed
-            "esinw_b": Parameter(0.2, "", fixed=False),     # Free - violation!
-            "Tc_b": Parameter(69.0, "days", fixed=True),
-            "g_HARPS": Parameter(0.0, "m/s", fixed=True),
-            "gd": Parameter(0.0, "m/s/day", fixed=True),
-            "gdd": Parameter(0.0, "m/s/day^2", fixed=True),
-            "jit_HARPS": Parameter(1.0, "m/s", fixed=False)
-        }
-        fitter = Fitter(["b"], Parameterisation("P K ecosw esinw Tc"))
-        fitter.add_data(time=time, vel=vel, velerr=velerr, instrument=instrument, t0=2.0)
-        with pytest.raises(ValueError, match="ecosw_b and esinw_b must both be fixed or both be free"):
             fitter.params = params
 
     def test_missing_priors_should_fail(self, simple_test_data) -> None:
@@ -441,8 +366,8 @@ class TestParameterisationFlexibility:
         priors = {
             "P_b": Uniform(3, 7),
             "K_b": Uniform(0, 10),
-            "secosw_b": Uniform(-0.5, 0.5),
-            "sesinw_b": Uniform(-0.5, 0.5),
+            "secosw_b": Uniform(-1, 1),
+            "sesinw_b": Uniform(-1, 1),
             "Tc_b": Uniform(20, 30),
             "g_HARPS": Uniform(-10, 10),
             "jit_HARPS": Uniform(0, 5)


### PR DESCRIPTION
Summary:

* Added per-planet classification of log-posterior correction cases (`CASE_1`, `CASE_2`, `CASE_3`) in `Fitter` and `GPFitter`, with explicit handling and error messages for unsupported prior combinations. Each planet's correction is computed independently and summed.
* Implemented `_compute_logprob_corrections` to calculate and store the total log-Jacobian and prior-renormalisation corrections, along with a per-planet breakdown. These corrections are applied in the `log_probability` methods of both `Fitter` and `GPFitter`.
* Added `Parameterisation.log_jacobian_determinant()` to return the log absolute Jacobian determinant for the current parameterisation (`log(2)` for `secosw/sesinw`, else `0.0`).
* Disabled the `ecosw/esinw` parameterisation in `ALLOWED_PARAMETERISATIONS`, as its Jacobian is non-constant and not supported by this correction scheme. These are liable to be fully removed in the next release.
* Added a comprehensive new documentation page (`docs/logprob_corrections.md`) explaining the theory, classification cases, worked examples, implementation details, and empirical validation of the log-posterior corrections. This page is now included in the docs index. 