### PR TITLE
Feature/freeze params phase plot

### DIFF
--- a/src/ravest/fit.py
+++ b/src/ravest/fit.py
@@ -2342,7 +2342,7 @@ class Fitter:
             print(f"Saved {fname}")
         plt.show()
 
-    def plot_posterior_phase(self, planet_letter: str, discard_start: int = 0, discard_end: int = 0, thin: int = 1, show_CI: bool = True, title: str | None = None, ylabel_main: str | None = "Radial velocity [m s$^{-1}$]", xlabel: str | None = "Orbital phase", ylabel_residuals: str | None = "Residuals [m s$^{-1}$]", ylim: tuple | None = None, res_ylim: tuple | None = None, save: bool = False, fname: str = "posterior_phase.png", dpi: int = 100, n_smooth: int = 1000) -> None:
+    def plot_posterior_phase(self, planet_letter: str, discard_start: int = 0, discard_end: int = 0, thin: int = 1, show_CI: bool = True, title: str | None = None, ylabel_main: str | None = "Radial velocity [m s$^{-1}$]", xlabel: str | None = "Orbital phase", ylabel_residuals: str | None = "Residuals [m s$^{-1}$]", ylim: tuple | None = None, res_ylim: tuple | None = None, save: bool = False, fname: str = "posterior_phase.png", dpi: int = 100, n_smooth: int = 1000, freeze_params: dict[str, float | None] | None = None) -> None:
         """Plot phase-folded RV model with uncertainty bands from MCMC samples.
 
         Shows the phase-folded planetary signal with uncertainty bands calculated
@@ -2380,7 +2380,33 @@ class Fitter:
             The dpi to save the image at (default: 100)
         n_smooth : int, optional
             Number of points in the one-period smooth model curve (default: 1000).
+        freeze_params : dict[str, float or None] or None, optional
+            Freeze named planet parameters to fixed values during the
+            per-sample RV calculation (default: None, no freezing). Keys are
+            full planet-parameter names (e.g. ``"P_c"``, ``"Tc_c"``); a value
+            of ``None`` freezes the parameter at its posterior median, while a
+            float freezes it at that exact value. Freezing P and Tc makes every
+            sample fold identically, giving a crisp median model line, CI band
+            and residuals when a period has large posterior uncertainty (which
+            otherwise smears the folded model). This can often happen for
+            non-transiting planets, especially if sampling in Tp not Tc. Note
+            that the RV data are always folded around the median of time and
+            period; this argument only affects the planetary phase-folded RV
+            curve and CI shaded band.
+
+            Only planet parameters of the active parameterisation can be frozen,
+            not trend or instrument parameters (``gd``, ``gdd``, ``g_*``,
+            ``jit_*``). Keys should normally be for ``planet_letter``; freezing
+            a parameter for a different planet warns (though it still applies
+            when removing that planet's signal). Freezing a parameter that is
+            already fixed (not free) also warns (although you can freeze at a
+            different value from the value the parameter was fixed at during
+            fitting).
         """
+        # Resolve any frozen parameter values (None -> posterior median) up front,
+        # so the fold reference and the per-sample RV calls stay consistent.
+        resolved_freeze = self._resolve_freeze_params(freeze_params, discard_start=discard_start, discard_end=discard_end, thin=thin, planet_letter=planet_letter)
+
         # Get period (handle both free and fixed cases)
         samples_dict = self.get_samples_dict(discard_start=discard_start, discard_end=discard_end, thin=thin)
 
@@ -2398,19 +2424,30 @@ class Fitter:
                 jit_med = self.fixed_params_values_dict[jit_key]
             velerr_with_jit[mask] = np.sqrt(self.velerr[mask]**2 + jit_med**2)
 
+        # Per-planet parameter samples for the target planet, with any frozen
+        # values substituted in. A frozen parameter replaces its sample array
+        # with the fixed scalar, so the fold reference below matches the
+        # (frozen) per-sample model curve and data folds identically.
+        planet_params = {par: params[f"{par}_{planet_letter}"] for par in self.parameterisation.pars}
+        if resolved_freeze:
+            for par in self.parameterisation.pars:
+                key = f"{par}_{planet_letter}"
+                if key in resolved_freeze:
+                    planet_params[par] = resolved_freeze[key]
+
         # Get period value
-        _P = params[f'P_{planet_letter}']
+        _P = planet_params["P"]
 
         # Get (or calculate) Tc for this planet for folding around
         if "Tc" in self.parameterisation.pars:
-            _Tc = params[f"Tc_{planet_letter}"]
+            _Tc = planet_params["Tc"]
         else:
             # Fall back to default parameterisation conversion (as it has P, e, w and Tp, so we can definitely get Tc)
-            planet_params = {par: params[f"{par}_{planet_letter}"] for par in self.parameterisation.pars}
             default_params = self.parameterisation.convert_pars_to_default_parameterisation(planet_params)
             _Tc = self.parameterisation.convert_tp_to_tc(default_params["Tp"], _P, default_params["e"], default_params["w"])
 
         # just for the folding, take the median value of the P and Tc samples
+        # (a frozen parameter is a scalar, so np.median returns it unchanged)
         Tc_med = np.median(_Tc)
         P_med = np.median(_P)
 
@@ -2425,15 +2462,18 @@ class Fitter:
 
 
         # Calculate RV components from MCMC samples (matrix of n_samples x n_obs, or n_samples x n_smooth)
-        rv_planet_data = self.calculate_rv_planet_from_samples(planet_letter, self.time, discard_start, discard_end, thin)
-        rv_planet_smooth = self.calculate_rv_planet_from_samples(planet_letter, tsmooth, discard_start, discard_end, thin)
+        # freeze_params is resolved (and any fixed-parameter warning emitted) once
+        # above; pass the resolved dict straight to the worker so the repeated
+        # per-planet calls here don't re-validate or re-warn.
+        rv_planet_data = self._calculate_rv_planet_from_samples(planet_letter, self.time, discard_start, discard_end, thin, resolved_freeze=resolved_freeze)
+        rv_planet_smooth = self._calculate_rv_planet_from_samples(planet_letter, tsmooth, discard_start, discard_end, thin, resolved_freeze=resolved_freeze)
         rv_trend_data = self.calculate_rv_trend_from_samples(self.time, discard_start, discard_end, thin)
 
         # Calculate RV contributions from all OTHER planets (not the target planet)
         rv_other_planets_data = np.zeros_like(rv_trend_data)
         for other_letter in self.planet_letters:
             if other_letter != planet_letter:
-                rv_other_planet = self.calculate_rv_planet_from_samples(other_letter, self.time, discard_start, discard_end, thin)
+                rv_other_planet = self._calculate_rv_planet_from_samples(other_letter, self.time, discard_start, discard_end, thin, resolved_freeze=resolved_freeze)
                 rv_other_planets_data += rv_other_planet
 
         # Combine all non-target contributions (other planets + trend)
@@ -2543,7 +2583,111 @@ class Fitter:
             print(f"Saved {fname}")
         plt.show()
 
-    def calculate_rv_planet_from_samples(self, planet_letter: str, times: np.ndarray, discard_start: int = 0, discard_end: int = 0, thin: int = 1, progress: bool = False) -> np.ndarray:
+    def _resolve_freeze_params(self, freeze_params: dict[str, float | None] | None, discard_start: int = 0, discard_end: int = 0, thin: int = 1, planet_letter: str | None = None) -> dict[str, float] | None:
+        """Validate and resolve a ``freeze_params`` mapping for phase plotting.
+
+        Parameters
+        ----------
+        freeze_params : dict[str, float or None] or None
+            Mapping of full planet-parameter names (e.g. ``"P_c"``, ``"Tc_c"``)
+            to the value to freeze them at. A value of ``None`` freezes the
+            parameter at its posterior median, computed from the requested
+            samples (a fixed parameter resolves to its fixed value). If
+            ``None``, this method returns ``None``.
+        discard_start : int, optional
+            Discard the first ``discard_start`` steps from the chain (default: 0).
+            Only used to compute medians for any ``None``-valued entries.
+        discard_end : int, optional
+            Discard the last ``discard_end`` steps from the chain (default: 0).
+            Only used to compute medians for any ``None``-valued entries.
+        thin : int, optional
+            Use only every ``thin`` steps from the chain (default: 1).
+            Only used to compute medians for any ``None``-valued entries.
+        planet_letter : str or None, optional
+            The planet the freeze is being applied for (default: None). If
+            given, a key whose planet letter differs from ``planet_letter``
+            warns, since freezing usually targets the plotted planet.
+
+        Returns
+        -------
+        dict[str, float] or None
+            Mapping with every value resolved to a float, or ``None`` if
+            ``freeze_params`` was ``None``.
+
+        Raises
+        ------
+        ValueError
+            If a key is not a recognised planet parameter of the active
+            parameterisation.
+
+        Warns
+        -----
+        UserWarning
+            If a key names a parameter that is already fixed (not free), or (when
+            ``planet_letter`` is given) a parameter for a different planet.
+            Neither is forbidden, but both usually mean the wrong key was passed.
+        """
+        if freeze_params is None:
+            return None
+
+        valid_names = {f"{par}_{letter}" for par in self.parameterisation.pars for letter in self.planet_letters}
+        unknown = set(freeze_params) - valid_names
+        if unknown:
+            raise ValueError(
+                f"Unknown freeze_params key(s): {sorted(unknown)}. Keys must be "
+                f"planet parameters of the active parameterisation, i.e. one of "
+                f"{sorted(valid_names)}."
+            )
+
+        # Warn if a key targets a planet other than the one being plotted: the
+        # phase plot is for a single planet, so freezing another planet's
+        # parameter almost always means the wrong planet letter was passed. Not
+        # forbidden (it still applies when removing that planet's signal).
+        if planet_letter is not None:
+            wrong_planet = [key for key in freeze_params if key.rsplit("_", 1)[-1] != planet_letter]
+            if wrong_planet:
+                warnings.warn(
+                    f"freeze_params names parameter(s) for a different planet than "
+                    f"'{planet_letter}': {sorted(wrong_planet)}. Freezing is intended "
+                    f"for the target planet's parameters (typically P and Tc); check "
+                    f"the planet letter.",
+                    UserWarning,
+                    stacklevel=2,
+                )
+
+        # Freezing only matters for parameters that vary across samples. Freezing
+        # a parameter that is already fixed has no de-smearing effect, so it most
+        # likely signals a wrong parameter name or a misunderstanding of what
+        # freezing does. It is not forbidden (freezing a fixed parameter to a
+        # different value is still allowed), but warn loudly.
+        fixed_frozen = [key for key in freeze_params if key not in self.free_params_names]
+        if fixed_frozen:
+            warnings.warn(
+                f"freeze_params names parameter(s) that are already fixed, not free: "
+                f"{sorted(fixed_frozen)}. Freezing only affects parameters that vary "
+                f"across posterior samples, so this has no de-smearing effect "
+                f"(a None value just resolves to the fixed value). Did you mean a "
+                f"free parameter, or pass the wrong name?",
+                UserWarning,
+                stacklevel=2,
+            )
+
+        resolved: dict[str, float] = {}
+        samples_dict = None  # only loaded if a None value needs a median
+        for key, value in freeze_params.items():
+            if value is None:
+                if samples_dict is None:
+                    samples_dict = self.get_samples_dict(discard_start=discard_start, discard_end=discard_end, thin=thin)
+                if key in samples_dict:
+                    resolved[key] = float(np.median(samples_dict[key]))
+                else:
+                    # Fixed parameter: its "median" is just its fixed value.
+                    resolved[key] = float(self.fixed_params_values_dict[key])
+            else:
+                resolved[key] = float(value)
+        return resolved
+
+    def calculate_rv_planet_from_samples(self, planet_letter: str, times: np.ndarray, discard_start: int = 0, discard_end: int = 0, thin: int = 1, progress: bool = False, freeze_params: dict[str, float | None] | None = None) -> np.ndarray:
         """Calculate planetary RV for each MCMC sample.
 
         This calculates RV(params_i) for each MCMC sample i, preserving
@@ -2564,11 +2708,30 @@ class Fitter:
             Use every Nth sample (default: 1)
         progress : bool, optional
             Show progress bar (default: False)
+        freeze_params : dict[str, float or None] or None, optional
+            Mapping of full planet-parameter names (e.g. ``"P_c"``, ``"Tc_c"``)
+            to a value that overrides that parameter in every sample. A value
+            of ``None`` freezes the parameter at its posterior median. Used to
+            de-smear phase plots when a period has large posterior uncertainty;
+            see `plot_posterior_phase` (default: None, no freezing).
 
         Returns
         -------
         np.ndarray
             Shape (n_samples, len(times)) - RV for each sample
+        """
+        resolved_freeze = self._resolve_freeze_params(freeze_params, discard_start=discard_start, discard_end=discard_end, thin=thin, planet_letter=planet_letter)
+        return self._calculate_rv_planet_from_samples(planet_letter, times, discard_start=discard_start, discard_end=discard_end, thin=thin, progress=progress, resolved_freeze=resolved_freeze)
+
+    def _calculate_rv_planet_from_samples(self, planet_letter: str, times: np.ndarray, discard_start: int = 0, discard_end: int = 0, thin: int = 1, progress: bool = False, resolved_freeze: dict[str, float] | None = None) -> np.ndarray:
+        """Per-sample planet RV, applying an already-resolved freeze override.
+
+        Internal worker for `calculate_rv_planet_from_samples`. ``resolved_freeze``
+        must already be validated and resolved to concrete floats (see
+        `_resolve_freeze_params`); it is applied verbatim to each sample's params
+        without further validation or warnings, so callers that have already
+        resolved once (e.g. `plot_posterior_phase`) do not trigger duplicate
+        warnings.
         """
         samples = self.get_samples_np(discard_start=discard_start, discard_end=discard_end, thin=thin, flat=True)
         planet_rvs = np.zeros((len(samples), len(times)))
@@ -2577,6 +2740,10 @@ class Fitter:
         for i, row in iterator:
             # Build complete params dict for this sample
             params = self.build_params_dict(row)
+
+            # Substitute any frozen parameter values for this sample
+            if resolved_freeze:
+                params.update(resolved_freeze)
 
             # Use custom method
             planet_rvs[i, :] = self.calculate_rv_planet_custom(planet_letter, times, params)

--- a/src/ravest/fit.py
+++ b/src/ravest/fit.py
@@ -6512,7 +6512,7 @@ class GPFitter:
             print(f"Saved {fname}")
         plt.show()
 
-    def plot_posterior_phase(self, planet_letter: str, discard_start: int = 0, discard_end: int = 0, thin: int = 1, show_CI: bool = True, title: str | None = None, ylabel_main: str | None = "Radial velocity [m s$^{-1}$]", xlabel: str | None = "Orbital phase", ylabel_residuals: str | None = "Residuals [m s$^{-1}$]", ylim: tuple | None = None, res_ylim: tuple | None = None, save: bool = False, fname: str = "posterior_phase.png", dpi: int = 100, n_smooth: int = 500) -> None:
+    def plot_posterior_phase(self, planet_letter: str, discard_start: int = 0, discard_end: int = 0, thin: int = 1, show_CI: bool = True, title: str | None = None, ylabel_main: str | None = "Radial velocity [m s$^{-1}$]", xlabel: str | None = "Orbital phase", ylabel_residuals: str | None = "Residuals [m s$^{-1}$]", ylim: tuple | None = None, res_ylim: tuple | None = None, save: bool = False, fname: str = "posterior_phase.png", dpi: int = 100, n_smooth: int = 500, freeze_params: dict[str, float | None] | None = None) -> None:
         """Plot phase-folded GP RV model with uncertainty bands from MCMC samples.
 
         Calculates phase-folded planetary signal with uncertainty bands calculated
@@ -6552,7 +6552,36 @@ class GPFitter:
         n_smooth : int, optional
             Number of points in the one-period smooth model curve (default: 500).
             Reduce for faster plotting, increase for smoother curves.
+        freeze_params : dict[str, float or None] or None, optional
+            Freeze named planet parameters to fixed values during the
+            per-sample RV calculation (default: None, no freezing). Keys are
+            full planet-parameter names (e.g. ``"P_c"``, ``"Tc_c"``); a value
+            of ``None`` freezes the parameter at its posterior median, while a
+            float freezes it at that exact value. Freezing P and Tc makes every
+            sample fold identically, giving a crisp median model line, CI band
+            and residuals when a period has large posterior uncertainty (which
+            otherwise smears the folded model). This can often happen for
+            non-transiting planets, especially if sampling in Tp not Tc. Note
+            that the RV data are always folded around the median of time and
+            period; this argument only affects the planetary phase-folded RV
+            curve and CI shaded band. For the GP model, the GP mean is
+            conditioned on the residuals from the (frozen) planet and trend
+            model, so the removed GP component stays self-consistent with the
+            frozen parameters.
+
+            Only planet parameters of the active parameterisation can be frozen,
+            not trend, instrument or GP-hyperparameter parameters (``gd``,
+            ``gdd``, ``g_*``, ``jit_*``, ``gp_*``). Keys should normally be for
+            ``planet_letter``; freezing a parameter for a different planet warns
+            (though it still applies when removing that planet's signal).
+            Freezing a parameter that is already fixed (not free) also warns
+            (although you can freeze at a different value from the value the
+            parameter was fixed at during fitting).
         """
+        # Resolve any frozen parameter values (None -> posterior median) up front,
+        # so the fold reference and the per-sample RV calls stay consistent.
+        resolved_freeze = self._resolve_freeze_params(freeze_params, discard_start=discard_start, discard_end=discard_end, thin=thin, planet_letter=planet_letter)
+
         fig, (ax1, ax2) = plt.subplots(2, 1, figsize=(8, 5), gridspec_kw={'height_ratios': [3, 1], 'hspace': 0})
         fig.align_ylabels([ax1, ax2])
 
@@ -6586,19 +6615,30 @@ class GPFitter:
             else:
                 vel_corrected[mask] -= params_hyperparams[g_key]
 
+        # Per-planet parameter samples for the target planet, with any frozen
+        # values substituted in. A frozen parameter replaces its sample array
+        # with the fixed scalar, so the fold reference below matches the
+        # (frozen) per-sample model curve and data folds identically.
+        planet_params = {par: params_hyperparams[f"{par}_{planet_letter}"] for par in self.parameterisation.pars}
+        if resolved_freeze:
+            for par in self.parameterisation.pars:
+                key = f"{par}_{planet_letter}"
+                if key in resolved_freeze:
+                    planet_params[par] = resolved_freeze[key]
+
         # Get period value
-        _P = params_hyperparams[f'P_{planet_letter}']
+        _P = planet_params["P"]
 
         # Get (or calculate) Tc for this planet for folding around
         if "Tc" in self.parameterisation.pars:
-            _Tc = params_hyperparams[f"Tc_{planet_letter}"]
+            _Tc = planet_params["Tc"]
         else:
             # Fall back to default parameterisation conversion (as it has P, e, w and Tp, so we can definitely get Tc)
-            planet_params = {par: params_hyperparams[f"{par}_{planet_letter}"] for par in self.parameterisation.pars}
             default_params = self.parameterisation.convert_pars_to_default_parameterisation(planet_params)
             _Tc = self.parameterisation.convert_tp_to_tc(default_params["Tp"], _P, default_params["e"], default_params["w"])
 
         # just for the folding, take the median value of the P and Tc samples
+        # (a frozen parameter is a scalar, so np.median returns it unchanged)
         Tc = np.median(_Tc)
         P = np.median(_P)
 
@@ -6629,18 +6669,22 @@ class GPFitter:
         # 11) Residuals panel
            # subtract planet (only) RV obs, from the matrix data - (other planets + trend + GP mean)
 
+        # freeze_params is resolved (and any warning emitted) once above; pass the
+        # resolved dict straight to the worker so the repeated per-planet calls
+        # here don't re-validate or re-warn. The GP mean in step 4 is conditioned
+        # on residuals built from these (frozen) planet RVs, so it stays consistent.
         # 1) Calculate this planet's RVs at obs times and at smooth times
         print(f"Calculating planet {planet_letter} RV at {len(self.time)} observed times...")
-        rv_this_planet_matrix_obs = self.calculate_rv_planet_from_samples(planet_letter, self.time, discard_start, discard_end, thin)
+        rv_this_planet_matrix_obs = self._calculate_rv_planet_from_samples(planet_letter, self.time, discard_start, discard_end, thin, resolved_freeze=resolved_freeze)
         print(f"Calculating planet {planet_letter} RV at {len(tsmooth)} smooth times...")
-        rv_this_planet_matrix_smooth = self.calculate_rv_planet_from_samples(planet_letter, tsmooth, discard_start, discard_end, thin)
+        rv_this_planet_matrix_smooth = self._calculate_rv_planet_from_samples(planet_letter, tsmooth, discard_start, discard_end, thin, resolved_freeze=resolved_freeze)
 
         # 2) Calculate all the other planets' RVs at obs times
         rv_other_planets_matrix_obs = np.zeros((rv_this_planet_matrix_obs.shape[0], len(self.time)))
         for other_letter in self.planet_letters:
             if other_letter != planet_letter:
                 print(f"Calculating planet {other_letter} RV at {len(self.time)} observed times...")
-                rv_other_planets_matrix_obs += self.calculate_rv_planet_from_samples(other_letter, self.time, discard_start, discard_end, thin)
+                rv_other_planets_matrix_obs += self._calculate_rv_planet_from_samples(other_letter, self.time, discard_start, discard_end, thin, resolved_freeze=resolved_freeze)
 
         # 3) Calculate trend at obs times
         print(f"Calculating trend RV at {len(self.time)} observed times...")
@@ -7090,7 +7134,111 @@ class GPFitter:
         self._plot_phase(planet_letter, all_params, title=title, ylabel_main=ylabel_main, xlabel=xlabel, ylabel_residuals=ylabel_residuals,
                         ylim=ylim, res_ylim=res_ylim, save=save, fname=fname, dpi=dpi)
 
-    def calculate_rv_planet_from_samples(self, planet_letter: str, times: np.ndarray, discard_start: int = 0, discard_end: int = 0, thin: int = 1, progress: bool = True) -> np.ndarray:
+    def _resolve_freeze_params(self, freeze_params: dict[str, float | None] | None, discard_start: int = 0, discard_end: int = 0, thin: int = 1, planet_letter: str | None = None) -> dict[str, float] | None:
+        """Validate and resolve a ``freeze_params`` mapping for phase plotting.
+
+        Parameters
+        ----------
+        freeze_params : dict[str, float or None] or None
+            Mapping of full planet-parameter names (e.g. ``"P_c"``, ``"Tc_c"``)
+            to the value to freeze them at. A value of ``None`` freezes the
+            parameter at its posterior median, computed from the requested
+            samples (a fixed parameter resolves to its fixed value). If
+            ``None``, this method returns ``None``.
+        discard_start : int, optional
+            Discard the first ``discard_start`` steps from the chain (default: 0).
+            Only used to compute medians for any ``None``-valued entries.
+        discard_end : int, optional
+            Discard the last ``discard_end`` steps from the chain (default: 0).
+            Only used to compute medians for any ``None``-valued entries.
+        thin : int, optional
+            Use only every ``thin`` steps from the chain (default: 1).
+            Only used to compute medians for any ``None``-valued entries.
+        planet_letter : str or None, optional
+            The planet the freeze is being applied for (default: None). If
+            given, a key whose planet letter differs from ``planet_letter``
+            warns, since freezing usually targets the plotted planet.
+
+        Returns
+        -------
+        dict[str, float] or None
+            Mapping with every value resolved to a float, or ``None`` if
+            ``freeze_params`` was ``None``.
+
+        Raises
+        ------
+        ValueError
+            If a key is not a recognised planet parameter of the active
+            parameterisation.
+
+        Warns
+        -----
+        UserWarning
+            If a key names a parameter that is already fixed (not free), or (when
+            ``planet_letter`` is given) a parameter for a different planet.
+            Neither is forbidden, but both usually mean the wrong key was passed.
+        """
+        if freeze_params is None:
+            return None
+
+        valid_names = {f"{par}_{letter}" for par in self.parameterisation.pars for letter in self.planet_letters}
+        unknown = set(freeze_params) - valid_names
+        if unknown:
+            raise ValueError(
+                f"Unknown freeze_params key(s): {sorted(unknown)}. Keys must be "
+                f"planet parameters of the active parameterisation, i.e. one of "
+                f"{sorted(valid_names)}."
+            )
+
+        # Warn if a key targets a planet other than the one being plotted: the
+        # phase plot is for a single planet, so freezing another planet's
+        # parameter almost always means the wrong planet letter was passed. Not
+        # forbidden (it still applies when removing that planet's signal).
+        if planet_letter is not None:
+            wrong_planet = [key for key in freeze_params if key.rsplit("_", 1)[-1] != planet_letter]
+            if wrong_planet:
+                warnings.warn(
+                    f"freeze_params names parameter(s) for a different planet than "
+                    f"'{planet_letter}': {sorted(wrong_planet)}. Freezing is intended "
+                    f"for the target planet's parameters (typically P and Tc); check "
+                    f"the planet letter.",
+                    UserWarning,
+                    stacklevel=2,
+                )
+
+        # Freezing only matters for parameters that vary across samples. Freezing
+        # a parameter that is already fixed has no de-smearing effect, so it most
+        # likely signals a wrong parameter name or a misunderstanding of what
+        # freezing does. It is not forbidden (freezing a fixed parameter to a
+        # different value is still allowed), but warn loudly.
+        fixed_frozen = [key for key in freeze_params if key not in self.free_params_names]
+        if fixed_frozen:
+            warnings.warn(
+                f"freeze_params names parameter(s) that are already fixed, not free: "
+                f"{sorted(fixed_frozen)}. Freezing only affects parameters that vary "
+                f"across posterior samples, so this has no de-smearing effect "
+                f"(a None value just resolves to the fixed value). Did you mean a "
+                f"free parameter, or pass the wrong name?",
+                UserWarning,
+                stacklevel=2,
+            )
+
+        resolved: dict[str, float] = {}
+        samples_dict = None  # only loaded if a None value needs a median
+        for key, value in freeze_params.items():
+            if value is None:
+                if samples_dict is None:
+                    samples_dict = self.get_samples_dict(discard_start=discard_start, discard_end=discard_end, thin=thin)
+                if key in samples_dict:
+                    resolved[key] = float(np.median(samples_dict[key]))
+                else:
+                    # Fixed parameter: its "median" is just its fixed value.
+                    resolved[key] = float(self.fixed_params_values_dict[key])
+            else:
+                resolved[key] = float(value)
+        return resolved
+
+    def calculate_rv_planet_from_samples(self, planet_letter: str, times: np.ndarray, discard_start: int = 0, discard_end: int = 0, thin: int = 1, progress: bool = True, freeze_params: dict[str, float | None] | None = None) -> np.ndarray:
         """Calculate planetary RV for each MCMC sample.
 
         This calculates RV(params_i) for each MCMC sample i, preserving
@@ -7111,11 +7259,30 @@ class GPFitter:
             Use every Nth sample (default: 1)
         progress : bool, optional
             Show progress bar (default: True)
+        freeze_params : dict[str, float or None] or None, optional
+            Mapping of full planet-parameter names (e.g. ``"P_c"``, ``"Tc_c"``)
+            to a value that overrides that parameter in every sample. A value
+            of ``None`` freezes the parameter at its posterior median. Used to
+            de-smear phase plots when a period has large posterior uncertainty;
+            see `plot_posterior_phase` (default: None, no freezing).
 
         Returns
         -------
         np.ndarray
             Shape (n_samples, len(times)) - RV for each sample
+        """
+        resolved_freeze = self._resolve_freeze_params(freeze_params, discard_start=discard_start, discard_end=discard_end, thin=thin, planet_letter=planet_letter)
+        return self._calculate_rv_planet_from_samples(planet_letter, times, discard_start=discard_start, discard_end=discard_end, thin=thin, progress=progress, resolved_freeze=resolved_freeze)
+
+    def _calculate_rv_planet_from_samples(self, planet_letter: str, times: np.ndarray, discard_start: int = 0, discard_end: int = 0, thin: int = 1, progress: bool = True, resolved_freeze: dict[str, float] | None = None) -> np.ndarray:
+        """Per-sample planet RV, applying an already-resolved freeze override.
+
+        Internal worker for `calculate_rv_planet_from_samples`. ``resolved_freeze``
+        must already be validated and resolved to concrete floats (see
+        `_resolve_freeze_params`); it is applied verbatim to each sample's params
+        without further validation or warnings, so callers that have already
+        resolved once (e.g. `plot_posterior_phase`) do not trigger duplicate
+        warnings.
         """
         samples = self.get_samples_np(discard_start=discard_start, discard_end=discard_end, thin=thin, flat=True)
         planet_rvs = np.zeros((len(samples), len(times)))
@@ -7124,6 +7291,10 @@ class GPFitter:
         for i, combined_sample in iterator:
             # Build complete params dict for this sample (includes hyperparams)
             params = self.build_params_dict(combined_sample)
+
+            # Substitute any frozen parameter values for this sample
+            if resolved_freeze:
+                params.update(resolved_freeze)
 
             # Use custom method
             planet_rvs[i, :] = self.calculate_rv_planet_custom(planet_letter, times, params)

--- a/tests/test_fit.py
+++ b/tests/test_fit.py
@@ -2406,6 +2406,69 @@ class TestGPRVCalculations:
         assert gp_samples.shape[1] == len(times)
         assert np.all(np.isfinite(gp_samples))
 
+    def _run_short_gp_mcmc(self, fitter):
+        """Run a short MCMC on the GPFitter (helper for freeze_params tests)."""
+        nwalkers = 14
+        map_result = fitter.find_map_estimate()
+        initial_positions = fitter.generate_initial_walker_positions_from_map(map_result, nwalkers=nwalkers)
+        fitter.run_mcmc(initial_positions, nwalkers=nwalkers, max_steps=50, progress=False)
+
+    def test_resolve_freeze_params_none(self, setup_gpfitter_for_rv):
+        """None passes straight through as None (no freezing)."""
+        fitter = setup_gpfitter_for_rv
+        assert fitter._resolve_freeze_params(None) is None
+
+    def test_resolve_freeze_params_unknown_key_raises(self, setup_gpfitter_for_rv):
+        """An unrecognised key raises ValueError."""
+        fitter = setup_gpfitter_for_rv
+        with pytest.raises(ValueError, match="Unknown freeze_params key"):
+            fitter._resolve_freeze_params({"P_c": None})
+
+    def test_resolve_freeze_params_rejects_non_planet_params(self, setup_gpfitter_for_rv):
+        """Trend, instrument and GP hyperparameters cannot be frozen."""
+        fitter = setup_gpfitter_for_rv
+        for key in ("jit_HARPS", "g_HARPS", "gd", "gp_amp", "gp_period"):
+            with pytest.raises(ValueError, match="Unknown freeze_params key"):
+                fitter._resolve_freeze_params({key: None})
+
+    def test_resolve_freeze_params_fixed_param_warns(self, setup_gpfitter_for_rv):
+        """Freezing a parameter that is already fixed warns (but is allowed)."""
+        fitter = setup_gpfitter_for_rv
+        with pytest.warns(UserWarning, match="already fixed"):
+            resolved = fitter._resolve_freeze_params({"P_b": 9.9})
+        assert resolved == {"P_b": 9.9}
+
+    def test_calculate_rv_planet_from_samples_freeze_constant(self, setup_gpfitter_for_rv):
+        """Freezing all planet parameters makes every sample's RV identical."""
+        fitter = setup_gpfitter_for_rv
+        self._run_short_gp_mcmc(fitter)
+
+        times = np.array([0.0, 0.5, 1.0, 1.5])
+        frozen = {"P_b": 2.0, "K_b": 5.0, "e_b": 0.0, "w_b": np.pi / 2, "Tc_b": 0.0}
+
+        rv_samples = fitter.calculate_rv_planet_from_samples('b', times, discard_start=10, thin=5, progress=False, freeze_params=frozen)
+
+        # With every planet parameter frozen, the planet RV no longer depends on
+        # the sample, so all rows are identical and match a single custom calc.
+        assert np.allclose(rv_samples, rv_samples[0:1], atol=1e-12)
+        params = fitter.build_params_dict(
+            list(fitter.free_params_values) + list(fitter.free_hyperparams_values)
+        ) | frozen
+        expected = fitter.calculate_rv_planet_custom('b', times, params)
+        np.testing.assert_allclose(rv_samples[0], expected, atol=1e-12)
+
+    def test_plot_posterior_phase_freeze_params(self, setup_gpfitter_for_rv):
+        """GPFitter.plot_posterior_phase runs with freeze_params (median and explicit)."""
+        import matplotlib
+        matplotlib.use('Agg')
+
+        fitter = setup_gpfitter_for_rv
+        self._run_short_gp_mcmc(fitter)
+
+        # None -> median, and explicit float, both accepted
+        fitter.plot_posterior_phase('b', discard_start=10, thin=5, n_smooth=50, freeze_params={"P_b": None, "Tc_b": None})
+        fitter.plot_posterior_phase('b', discard_start=10, thin=5, n_smooth=50, freeze_params={"P_b": 2.0, "Tc_b": 0.0})
+
 
 class TestGPFitterIntegration:
     """Integration tests for complete GPFitter workflow."""

--- a/tests/test_fit.py
+++ b/tests/test_fit.py
@@ -1,3 +1,5 @@
+import warnings
+
 import jax.numpy as jnp
 import numpy as np
 import pytest
@@ -1061,6 +1063,28 @@ class TestRVCalculations:
         fitter.priors = test_simple_priors
         return fitter
 
+    @pytest.fixture
+    def setup_fitter_two_planets(self, test_data):
+        """Two-planet fitter (b and c) for freeze_params planet-letter tests."""
+        fitter = Fitter(["b", "c"], Parameterisation("P K e w Tc"))
+        time, vel, velerr, instrument = test_data
+        fitter.add_data(time, vel, velerr, instrument, t0=2.0)
+        fitter.params = {
+            "P_b": Parameter(2.0, "d", fixed=True), "K_b": Parameter(5.0, "m/s", fixed=False),
+            "e_b": Parameter(0.0, "", fixed=True), "w_b": Parameter(np.pi/2, "rad", fixed=True),
+            "Tc_b": Parameter(0.0, "d", fixed=True),
+            "P_c": Parameter(8.0, "d", fixed=True), "K_c": Parameter(3.0, "m/s", fixed=False),
+            "e_c": Parameter(0.0, "", fixed=True), "w_c": Parameter(np.pi/2, "rad", fixed=True),
+            "Tc_c": Parameter(1.0, "d", fixed=True),
+            "g_HARPS": Parameter(0.0, "m/s", fixed=True), "gd": Parameter(0.0, "m/s/day", fixed=True),
+            "gdd": Parameter(0.0, "m/s/day^2", fixed=True), "jit_HARPS": Parameter(1.0, "m/s", fixed=False),
+        }
+        fitter.priors = {
+            "K_b": ravest.prior.Uniform(0, 20), "K_c": ravest.prior.Uniform(0, 20),
+            "jit_HARPS": ravest.prior.Uniform(0, 5),
+        }
+        return fitter
+
     def test_calculate_rv_planet_custom(self, setup_fitter_for_rv):
         """Test custom planet RV against hand-calculated circular orbit values.
 
@@ -1216,6 +1240,181 @@ class TestRVCalculations:
         assert trend_samples.ndim == 2
         assert trend_samples.shape[1] == len(times)
         assert np.all(np.isfinite(trend_samples))
+
+    def _run_short_mcmc(self, fitter):
+        """Run a short MCMC on the fitter (helper for freeze_params tests)."""
+        map_result = fitter.find_map_estimate()
+        initial_positions = fitter.generate_initial_walker_positions_from_map(map_result, nwalkers=10)
+        fitter.run_mcmc(initial_positions, nwalkers=10, max_steps=50, progress=False)
+
+    def test_resolve_freeze_params_none(self, setup_fitter_for_rv):
+        """None passes straight through as None (no freezing)."""
+        fitter = setup_fitter_for_rv
+        assert fitter._resolve_freeze_params(None) is None
+
+    def test_resolve_freeze_params_explicit_values(self, setup_fitter_for_rv):
+        """Explicit float values are returned unchanged (as floats)."""
+        fitter = setup_fitter_for_rv
+        resolved = fitter._resolve_freeze_params({"P_b": 2.0, "Tc_b": 0.5})
+        assert resolved == {"P_b": 2.0, "Tc_b": 0.5}
+        assert all(isinstance(v, float) for v in resolved.values())
+
+    def test_resolve_freeze_params_none_value_uses_median(self, setup_fitter_for_rv):
+        """A None value resolves to the parameter's posterior median."""
+        fitter = setup_fitter_for_rv
+        self._run_short_mcmc(fitter)
+
+        # K_b is the only free planet parameter in this fixture
+        resolved = fitter._resolve_freeze_params({"K_b": None}, discard_start=10, thin=5)
+        samples_dict = fitter.get_samples_dict(discard_start=10, thin=5)
+        expected = float(np.median(samples_dict["K_b"]))
+        assert resolved["K_b"] == pytest.approx(expected)
+
+    def test_resolve_freeze_params_unknown_key_raises(self, setup_fitter_for_rv):
+        """An unrecognised key raises ValueError."""
+        fitter = setup_fitter_for_rv
+        with pytest.raises(ValueError, match="Unknown freeze_params key"):
+            fitter._resolve_freeze_params({"P_c": None})
+
+    def test_resolve_freeze_params_rejects_non_planet_params(self, setup_fitter_for_rv):
+        """Trend and instrument parameters cannot be frozen (planet params only)."""
+        fitter = setup_fitter_for_rv
+        for key in ("jit_HARPS", "g_HARPS", "gd", "gdd"):
+            with pytest.raises(ValueError, match="Unknown freeze_params key"):
+                fitter._resolve_freeze_params({key: None})
+
+    def test_resolve_freeze_params_wrong_planet_warns(self, setup_fitter_two_planets):
+        """Freezing a parameter for a planet other than planet_letter warns."""
+        fitter = setup_fitter_two_planets
+        # Plotting 'b' but freezing K_c (planet c, and free -> no fixed warning)
+        with pytest.warns(UserWarning, match="different planet"):
+            resolved = fitter._resolve_freeze_params({"K_c": 3.0}, planet_letter="b")
+        # Still applied (not banned)
+        assert resolved == {"K_c": 3.0}
+
+    def test_resolve_freeze_params_correct_planet_no_warn(self, setup_fitter_two_planets):
+        """Freezing a free parameter of the target planet does not warn."""
+        fitter = setup_fitter_two_planets
+        with warnings.catch_warnings():
+            warnings.simplefilter("error")  # any warning becomes an error
+            fitter._resolve_freeze_params({"K_b": 5.0}, planet_letter="b")
+
+    def test_resolve_freeze_params_no_planet_letter_no_wrong_planet_warn(self, setup_fitter_two_planets):
+        """Without planet_letter, no cross-planet warning is emitted."""
+        fitter = setup_fitter_two_planets
+        with warnings.catch_warnings(record=True) as record:
+            warnings.simplefilter("always")
+            fitter._resolve_freeze_params({"K_c": 3.0})  # K_c free, no planet_letter
+        assert not [w for w in record if "different planet" in str(w.message)]
+
+    def test_plot_posterior_phase_freeze_wrong_planet_warns_once(self, setup_fitter_two_planets):
+        """Plotting one planet but freezing another's parameter warns exactly once."""
+        import matplotlib
+        matplotlib.use('Agg')
+
+        fitter = setup_fitter_two_planets
+        self._run_short_mcmc(fitter)
+
+        with warnings.catch_warnings(record=True) as record:
+            warnings.simplefilter("always")  # worst case: no de-duplication
+            # Plot planet 'b' but freeze K_c (planet c, free)
+            fitter.plot_posterior_phase('b', discard_start=10, thin=5, freeze_params={"K_c": None})
+        wrong_planet = [w for w in record if "different planet" in str(w.message)]
+        assert len(wrong_planet) == 1
+
+    def test_resolve_freeze_params_fixed_param_warns(self, setup_fitter_for_rv):
+        """Freezing a parameter that is already fixed warns (but is allowed)."""
+        fitter = setup_fitter_for_rv
+        # P_b is fixed in this fixture; freezing it should warn.
+        with pytest.warns(UserWarning, match="already fixed"):
+            resolved = fitter._resolve_freeze_params({"P_b": 9.9})
+        # ...and still resolve to the requested value (not banned).
+        assert resolved == {"P_b": 9.9}
+
+    def test_resolve_freeze_params_free_param_no_warn(self, setup_fitter_for_rv):
+        """Freezing a free parameter does not warn."""
+        fitter = setup_fitter_for_rv
+        with warnings.catch_warnings():
+            warnings.simplefilter("error")  # any warning becomes an error
+            fitter._resolve_freeze_params({"K_b": 5.0})
+
+    def test_plot_posterior_phase_freeze_fixed_warns_once(self, setup_fitter_for_rv):
+        """A fixed-parameter freeze warns exactly once across the whole plot."""
+        import matplotlib
+        matplotlib.use('Agg')
+
+        fitter = setup_fitter_for_rv
+        self._run_short_mcmc(fitter)
+
+        with warnings.catch_warnings(record=True) as record:
+            warnings.simplefilter("always")  # worst case: no de-duplication
+            fitter.plot_posterior_phase('b', discard_start=10, thin=5, freeze_params={"P_b": None, "Tc_b": None})
+        fixed_warnings = [w for w in record if "already fixed" in str(w.message)]
+        assert len(fixed_warnings) == 1
+
+    def test_calculate_rv_planet_from_samples_freeze_constant(self, setup_fitter_for_rv):
+        """Freezing all planet parameters makes every sample's RV identical."""
+        fitter = setup_fitter_for_rv
+        self._run_short_mcmc(fitter)
+
+        times = np.array([0.0, 0.5, 1.0, 1.5])
+        frozen = {"P_b": 2.0, "K_b": 5.0, "e_b": 0.0, "w_b": np.pi / 2, "Tc_b": 0.0}
+
+        rv_samples = fitter.calculate_rv_planet_from_samples('b', times, discard_start=10, thin=5, freeze_params=frozen)
+
+        # With every planet parameter frozen, the planet RV no longer depends on
+        # the sample, so all rows are identical and match a single custom calc.
+        assert np.allclose(rv_samples, rv_samples[0:1], atol=1e-12)
+        params = fitter.build_params_dict(fitter.free_params_values) | frozen
+        expected = fitter.calculate_rv_planet_custom('b', times, params)
+        np.testing.assert_allclose(rv_samples[0], expected, atol=1e-12)
+
+    def test_calculate_rv_planet_from_samples_freeze_none_matches_median(self, setup_fitter_for_rv):
+        """Freezing at None gives the same result as freezing at the median value."""
+        fitter = setup_fitter_for_rv
+        self._run_short_mcmc(fitter)
+
+        times = np.array([0.0, 0.5, 1.0])
+        # K_b is the only free planet parameter in this fixture
+        samples_dict = fitter.get_samples_dict(discard_start=10, thin=5)
+        k_med = float(np.median(samples_dict["K_b"]))
+
+        rv_none = fitter.calculate_rv_planet_from_samples('b', times, discard_start=10, thin=5, freeze_params={"K_b": None})
+        rv_val = fitter.calculate_rv_planet_from_samples('b', times, discard_start=10, thin=5, freeze_params={"K_b": k_med})
+        np.testing.assert_allclose(rv_none, rv_val, atol=1e-12)
+
+    def test_calculate_rv_planet_from_samples_no_freeze_unchanged(self, setup_fitter_for_rv):
+        """Default (freeze_params=None) is unchanged from the original behaviour."""
+        fitter = setup_fitter_for_rv
+        self._run_short_mcmc(fitter)
+
+        times = np.array([0.0, 1.0, 2.0])
+        rv_default = fitter.calculate_rv_planet_from_samples('b', times, discard_start=10, thin=5)
+        rv_none = fitter.calculate_rv_planet_from_samples('b', times, discard_start=10, thin=5, freeze_params=None)
+        np.testing.assert_array_equal(rv_default, rv_none)
+
+    def test_plot_posterior_phase_freeze_params(self, setup_fitter_for_rv):
+        """plot_posterior_phase runs with freeze_params (median and explicit)."""
+        import matplotlib
+        matplotlib.use('Agg')
+
+        fitter = setup_fitter_for_rv
+        self._run_short_mcmc(fitter)
+
+        # None -> median, and explicit float, both accepted
+        fitter.plot_posterior_phase('b', discard_start=10, thin=5, freeze_params={"P_b": None, "Tc_b": None})
+        fitter.plot_posterior_phase('b', discard_start=10, thin=5, freeze_params={"P_b": 2.0, "Tc_b": 0.0})
+
+    def test_plot_posterior_phase_freeze_params_unknown_key_raises(self, setup_fitter_for_rv):
+        """plot_posterior_phase rejects an unknown freeze_params key."""
+        import matplotlib
+        matplotlib.use('Agg')
+
+        fitter = setup_fitter_for_rv
+        self._run_short_mcmc(fitter)
+
+        with pytest.raises(ValueError, match="Unknown freeze_params key"):
+            fitter.plot_posterior_phase('b', discard_start=10, thin=5, freeze_params={"Xyz_b": None})
 
     def test_calculate_rv_total_from_samples(self, setup_fitter_for_rv):
         """Test calculating total RV from MCMC samples."""


### PR DESCRIPTION
This PR adds support for freezing planetary parameters when plotting phase-folded RVs, which helps produce clearer plots when parameters like period or transit time have large uncertainties. This is especially useful for non-transiting planets where transit time / periastron time isn't well constrained.

- Added a `freeze_params` argument to `plot_posterior_phase` (both `Fitter` and `GPFitter` versions) and `calculate_rv_planet_from_samples`, allowing users to freeze planet parameters at fixed values or their posterior medians to "de-smear" phase plots.
- Introduced a helper method `_resolve_freeze_params` to validate and resolve the `freeze_params` mapping, warn on common mistakes, and ensure all frozen values are concrete floats.
- Refactored internal RV calculation logic to use `_calculate_rv_planet_from_samples`, which applies already-resolved frozen parameters efficiently and without duplicate warnings.